### PR TITLE
Add min-juju-version element to prevent excess PVC creation

### DIFF
--- a/charms/mlflow-server/metadata.yaml
+++ b/charms/mlflow-server/metadata.yaml
@@ -3,6 +3,7 @@
 name: mlflow-server
 description: |
   MLflow
+min-juju-version: "2.9.0"
 series: [kubernetes]
 summary: |
   A charm which provides a Kubernetes installation of the MLflow (https://mlflow.org/) server.


### PR DESCRIPTION
This PR addresses https://github.com/canonical/bundle-kubeflow/issues/425 where a PVC is created per operator, adding the `min-juju-version: 2.9.0` element to prevent that PVC creation.
