### PR TITLE
fix: add trailing '/' to uri in ingress

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -61,8 +61,11 @@ jobs:
         set -eux
         juju model-config update-status-hook-interval=15s
         juju deploy ch:istio --trust
-        juju config istio-pilot 'default-gateways=kubeflow-gateway'
-        sleep 10
+        juju deploy istio-gateway --channel=1.5/stable --trust istio-ingressgateway
+        juju deploy istio-pilot --channel=1.5/stable --config default-gateway=kubeflow-gateway
+        juju relate istio-pilot:istio-pilot istio-ingressgateway:istio-pilot
+        sleep 30
+        kubectl patch role -n kubeflow istio-ingressgateway-operator -p '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"name":"istio-ingressgateway-operator"},"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]}'
         juju wait -wvt 300 --retry_errors 20
         juju model-config update-status-hook-interval=5m
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -64,7 +64,7 @@ jobs:
         juju deploy istio-pilot --channel=1.5/stable --config default-gateway=kubeflow-gateway
         juju relate istio-pilot:istio-pilot istio-ingressgateway:istio-pilot
         sleep 30
-        kubectl patch role -n kubeflow istio-ingressgateway-operator -p '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"name":"istio-ingressgateway-operator"},"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]}'
+        kubectl patch role -n mlflow istio-ingressgateway-operator -p '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"name":"istio-ingressgateway-operator"},"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]}'
         juju wait -wvt 300 --retry_errors 20
         juju model-config update-status-hook-interval=5m
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -60,7 +60,6 @@ jobs:
       run: |
         set -eux
         juju model-config update-status-hook-interval=15s
-        juju deploy ch:istio --trust
         juju deploy istio-gateway --channel=1.5/stable --trust istio-ingressgateway
         juju deploy istio-pilot --channel=1.5/stable --config default-gateway=kubeflow-gateway
         juju relate istio-pilot:istio-pilot istio-ingressgateway:istio-pilot

--- a/charms/mlflow-server/src/charm.py
+++ b/charms/mlflow-server/src/charm.py
@@ -238,7 +238,7 @@ class Operator(CharmBase):
         if interfaces["ingress"]:
             interfaces["ingress"].send_data(
                 {
-                    "prefix": "/mlflow",
+                    "prefix": "/mlflow/",
                     "rewrite": "/",
                     "service": self.model.app.name,
                     "port": self.model.config["mlflow_port"],

--- a/tests/test_selenium.py
+++ b/tests/test_selenium.py
@@ -31,6 +31,7 @@ def driver(request):
     options = Options()
     options.headless = True
     options.log.level = "trace"
+    max_wait = 10  # seconds
 
     kwargs = {
         "options": options,
@@ -38,16 +39,8 @@ def driver(request):
     }
 
     with webdriver.Firefox(**kwargs) as driver:
-        wait = WebDriverWait(driver, 180, 1, (JavascriptException, StopIteration))
-        for _ in range(60):
-            try:
-                driver.get(url)
-                break
-            except WebDriverException:
-                sleep(5)
-        else:
-            driver.get(url)
-
+        wait = WebDriverWait(driver, max_wait)
+        driver.get(url)
         yield driver, wait, url
 
         Path(f"/tmp/selenium-{request.node.name}.har").write_text(driver.har)
@@ -60,4 +53,4 @@ def test_dashboard(driver):
     driver, wait, url = driver
 
     # TODO: More testing
-    wait.until(EC.presence_of_element_located((By.ID, "root")))
+    wait.until(EC.presence_of_element_located((By.CLASS_NAME, "experiment-view-container")))


### PR DESCRIPTION
fixes canonical/bundle-kubeflow#436

This fixes the istio ingress/virtualservice routing.  

Previously, the rewrite rule of `prefix=/mlflow` would serve a blank page at `INGRESS/mlflow` and a dead link at `INGRESS/mlflow/.  This appeared to be because the rewrite rules would break the static files that mlflow serves.  With this old rule (no trailing slash in the prefix) the static files get served at `INGRESS/static-files/...` rather than `INGRESS/mlflow/static-files/...` and are thus inaccessible.  

With this PR, the rewrite rule of `prefix=mlflow/` (including trailing slash) serves the correct mlflow UI at `INGRESS/mlflow/` with the static files correctly being accessed from `INGRESS/mlflow/static-files/...`.  But, this serves nothing at `INGRESS/mlflow`, which might be counter intuitive.  I tried to find some extra istio virtualiservice config that would get both to work, but I was not successful.

# Test instructions:
On a deployment with at least the istio-pilot, gateway, and possibly kubeflow-dashboard, do:
```
juju deploy mlflow-server
juju deploy cs:~charmed-osm/mariadb-k8s-35 mysql-mlflow
juju deploy minio minio-mlflow

juju relate mlflow-server mysql-mlflow
juju relate mlflow-server:object-storage minio-mlflow:object-storage
juju relate mlflow-server:ingress istio-pilot:ingress
```

Then browse to `INGRESSIP/mlflow/` (including trailing `/`).  The auth flow should occur and then get you to the mlflow UI
