### PR TITLE
feat: add mlflow s3 bucket name as config

### DIFF
--- a/charms/mlflow-server/config.yaml
+++ b/charms/mlflow-server/config.yaml
@@ -2,6 +2,11 @@
 # See LICENSE file for licensing details.
 #
 options:
+  default_artifact_root:
+    description: |
+      The name of the default bucket mlflow uses for artifacts, if not specified by the workflow
+    type: string
+    default: mlflow
   mlflow_port:
     description: |
       The port MLFlow will be listening on


### PR DESCRIPTION
Adds the "default_artifact_root" config value, which sets the s3 bucket that Argo Workflows uses as the default storage bucket (where it puts data if a Workflow does not specify its own bucket).  This is also useful in gateway mode, where you may use a bucket in an s3 store that already exists with a name.

fixes #24