### PR TITLE
fix: removed aws credentials from poddefault

### DIFF
--- a/charms/mlflow-server/src/charm.py
+++ b/charms/mlflow-server/src/charm.py
@@ -94,8 +94,6 @@ class Operator(CharmBase):
             {
                 "minio": {
                     "env": {
-                        "AWS_ACCESS_KEY_ID": obj_storage["access-key"],
-                        "AWS_SECRET_ACCESS_KEY": obj_storage["secret-key"],
                         "MLFLOW_S3_ENDPOINT_URL": endpoint,
                         "MLFLOW_TRACKING_URI": tracking,
                     }


### PR DESCRIPTION
https://github.com/canonical/bundle-kubeflow/issues/528

Summary of changes:
- Removed AWS credentials from PodDefault.