### PR TITLE
fix: Rename `seldon-rclone-secret` fields

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 
@@ -452,6 +452,7 @@ class MlflowCharm(CharmBase):
                 "s3_endpoint": f"http://{object_storage_data['service']}.{object_storage_data['namespace']}:{object_storage_data['port']}",  # noqa: E501
                 "s3_type": "s3",
                 "s3_provider": "minio",
+                "enable_env_auth": "false",
                 "access_key": object_storage_data["access-key"],
                 "secret_access_key": object_storage_data["secret-key"],
             }

--- a/src/secrets/mlflow-seldon-rclone-secret.j2
+++ b/src/secrets/mlflow-seldon-rclone-secret.j2
@@ -3,8 +3,9 @@ kind: Secret
 metadata:
   name: {{ app_name }}-seldon-rclone-secret
 stringData:
-  RCLONE_CONFIG_MYS3_TYPE: {{ s3_type }}
-  RCLONE_CONFIG_MYS3_PROVIDER: {{ s3_provider }}
-  RCLONE_CONFIG_MYS3_ACCESS_KEY_ID: {{ access_key }}
-  RCLONE_CONFIG_MYS3_SECRET_ACCESS_KEY: {{ secret_access_key }}
-  RCLONE_CONFIG_MYS3_ENDPOINT: {{ s3_endpoint }}
+  RCLONE_CONFIG_S3_TYPE: {{ s3_type }}
+  RCLONE_CONFIG_S3_PROVIDER: {{ s3_provider }}
+  RCLONE_CONFIG_S3_ENV_AUTH: {{ enable_env_auth }}
+  RCLONE_CONFIG_S3_ACCESS_KEY_ID: {{ access_key }}
+  RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: {{ secret_access_key }}
+  RCLONE_CONFIG_S3_ENDPOINT: {{ s3_endpoint }}


### PR DESCRIPTION
Rename the fields provided in the `rclone` Secret to match the names that the Seldon storage initializer expects.

Closes #182 