### PR TITLE
fix: Pass `ENV_AUTH` value as string

### DIFF
--- a/src/secrets/mlflow-seldon-rclone-secret.j2
+++ b/src/secrets/mlflow-seldon-rclone-secret.j2
@@ -5,7 +5,7 @@ metadata:
 stringData:
   RCLONE_CONFIG_S3_TYPE: {{ s3_type }}
   RCLONE_CONFIG_S3_PROVIDER: {{ s3_provider }}
-  RCLONE_CONFIG_S3_ENV_AUTH: {{ enable_env_auth }}
+  RCLONE_CONFIG_S3_ENV_AUTH: "{{ enable_env_auth }}"
   RCLONE_CONFIG_S3_ACCESS_KEY_ID: {{ access_key }}
   RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: {{ secret_access_key }}
   RCLONE_CONFIG_S3_ENDPOINT: {{ s3_endpoint }}


### PR DESCRIPTION
According to the [Seldon docs](https://docs.seldon.io/projects/seldon-core/en/v1.14.0/servers/overview.html#example-minio-configuration), `RCLONE_CONFIG_S3_ENV_AUTH` receives a boolean value. However, passing `true` or `false` will cause the metacontroller to break when attempting to convert the Secret from JSON to a Go struct, since it's unable to unmarshall the boolean field. This in turn, will lead to the secret not being applied.

Consequently, we have to quote the boolean value to ensure it's interpreted as a string, e.g.
```yaml
RCLONE_CONFIG_S3_ENV_AUTH: "false"
```