### PR TITLE
feat: get images on track/2.1

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# dynamic list
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
closes #210 

## Testing
```bash
bash tools/get-images.sh
# Output
docker.io/ubuntu/mlflow:2.1.1_1.0-22.04
docker.io/charmedkubeflow/mlflow-prometheus-exporter:1.0-22.04
```