### PR TITLE
ci: Decrease root-reserve-mb to fit the new runner storage (#223)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,7 +57,7 @@ jobs:
     - name: Maximise GH runner space
       uses: easimon/maximize-build-space@v8
       with:
-        root-reserve-mb: 40960
+        root-reserve-mb: 29696
         remove-dotnet: 'true'
         remove-haskell: 'true'
         remove-android: 'true'


### PR DESCRIPTION
addresses https://github.com/canonical/bundle-kubeflow/issues/813
backports ed3621b453737483355a6c7e47abc941ee677080 to `track/2.1`