### PR TITLE
fix: use mysql-k8s `8.0/edge` in the integration tests and bundles (#225)

### DIFF
--- a/releases/2.1/beta/mlflow/bundle.yaml
+++ b/releases/2.1/beta/mlflow/bundle.yaml
@@ -10,7 +10,9 @@ applications:
     _github_repo_name: minio-operator
   mlflow-mysql:
     charm: mysql-k8s
-    channel: 8.0/stable
+    # We should use `8.0/stable` once changes for
+    # https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
+    channel: 8.0/edge
     scale: 1
     trust: true
     _github_repo_name: mysql-k8s-operator

--- a/releases/2.1/edge/mlflow/bundle.yaml
+++ b/releases/2.1/edge/mlflow/bundle.yaml
@@ -10,7 +10,9 @@ applications:
     _github_repo_name: minio-operator
   mlflow-mysql:
     charm: mysql-k8s
-    channel: 8.0/stable
+    # We should use `8.0/stable` once changes for
+    # https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
+    channel: 8.0/edge
     scale: 1
     trust: true
     _github_repo_name: mysql-k8s-operator

--- a/releases/2.1/stable/mlflow/bundle.yaml
+++ b/releases/2.1/stable/mlflow/bundle.yaml
@@ -10,7 +10,9 @@ applications:
     _github_repo_name: minio-operator
   mlflow-mysql:
     charm: mysql-k8s
-    channel: 8.0/stable
+    # We should use `8.0/stable` once changes for
+    # https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
+    channel: 8.0/edge
     scale: 1
     trust: true
     _github_repo_name: mysql-k8s-operator

--- a/releases/latest/beta/mlflow/bundle.yaml
+++ b/releases/latest/beta/mlflow/bundle.yaml
@@ -10,7 +10,9 @@ applications:
     _github_repo_name: minio-operator
   mlflow-mysql:
     charm: mysql-k8s
-    channel: 8.0/stable
+    # We should use `8.0/stable` once changes for
+    # https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
+    channel: 8.0/edge
     scale: 1
     trust: true
     _github_repo_name: mysql-k8s-operator

--- a/releases/latest/edge/mlflow/bundle.yaml
+++ b/releases/latest/edge/mlflow/bundle.yaml
@@ -10,7 +10,9 @@ applications:
     _github_repo_name: minio-operator
   mlflow-mysql:
     charm: mysql-k8s
-    channel: 8.0/stable
+    # We should use `8.0/stable` once changes for
+    # https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
+    channel: 8.0/edge
     scale: 1
     trust: true
     _github_repo_name: mysql-k8s-operator

--- a/releases/latest/stable/mlflow/bundle.yaml
+++ b/releases/latest/stable/mlflow/bundle.yaml
@@ -10,7 +10,9 @@ applications:
     _github_repo_name: minio-operator
   mlflow-mysql:
     charm: mysql-k8s
-    channel: 8.0/stable
+    # We should use `8.0/stable` once changes for
+    # https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
+    channel: 8.0/edge
     scale: 1
     trust: true
     _github_repo_name: mysql-k8s-operator

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -183,7 +183,9 @@ class TestCharm:
         )
         await ops_test.model.deploy(
             RELATIONAL_DB_CHARM_NAME,
-            channel="8.0/stable",
+            # We should use `8.0/stable` once changes for
+            # https://github.com/canonical/mysql-k8s-operator/issues/337 are published there.
+            channel="8.0/edge",
             series="jammy",
             trust=True,
         )


### PR DESCRIPTION
backports 270dff3fa97142a53de98bec75c16f77750d1de3 to `track/2.1`
* fix: use mysql-k8s edge
* fix: add comment to revert to stable