### PR TITLE
feat: add Terraform module for mlflow-server

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -50,6 +50,14 @@ jobs:
     - name: Run unit tests
       run: tox -e unit
 
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    with:
+      charm-path: .
+      model: kubeflow
+      channel: latest/edge
+
   integration:
     name: Integration tests (microk8s)
     runs-on: ubuntu-20.04

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,8 +55,12 @@ jobs:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
     with:
       charm-path: .
-      model: kubeflow
       channel: latest/edge
+      # Skipping the Terraform apply check as the mlflow-server goes to Waiting status
+      # instead of the expected Blocked or Active. This is currently a limitation of the
+      # Terraform re-usable workflows in canonical/charmed-kubeflow-workflows
+      # See https://github.com/canonical/charmed-kubeflow-workflows/issues/65
+      apply: false
 
   integration:
     name: Integration tests (microk8s)

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,7 @@ id_rsa
 kubeconfig
 *.charm
 .kube/
+
+venv/
+.terraform*
+*.tfstate*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,63 @@
+# Terraform module for training-operator
+
+This is a Terraform module facilitating the deployment of the mlflow-server charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Compatibility
+This terraform module is compatible with charms of version >= 1.8 due to changes in the charm's relations.
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = mlflow
+}
+
+module "mlflow-server" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "mlflow-server" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,7 +3,7 @@
 This is a Terraform module facilitating the deployment of the mlflow-server charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
 ## Compatibility
-This terraform module is compatible with charms of version >= 1.8 due to changes in the charm's relations.
+This terraform module is compatible with the mlflow-server charm 2.15/stable.
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,4 +1,4 @@
-# Terraform module for training-operator
+# Terraform module for mlflow-server
 
 This is a Terraform module facilitating the deployment of the mlflow-server charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "mlflow_server" {
+  charm {
+    name     = "mlflow-server"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -11,11 +11,11 @@ output "provides" {
 
 output "requires" {
   value = {
-    relational_db = "relational-db"
-    object_storage = "object-storage"
-    dashboard_links = "dashboard-links"
-    ingress = "ingress"
-    secrets = "secrets"
-    pod_defaults = "pod-defaults"
+    dashboard_links = "dashboard-links",
+    ingress = "ingress",
+    object_storage = "object-storage",
+    pod_defaults = "pod-defaults",
+    relational_db = "relational-db",
+    secrets = "secrets",
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,21 @@
+output "app_name" {
+  value = juju_application.mlflow_server.name
+}
+
+output "provides" {
+  value = {
+    grafana_dashboard = "grafana-dashboard",
+    metrics_endpoint  = "metrics-endpoint",
+  }
+}
+
+output "requires" {
+  value = {
+    relational_db = "relational-db"
+    object_storage = "object-storage"
+    dashboard_links = "dashboard-links"
+    ingress = "ingress"
+    secrets = "secrets"
+    pod_defaults = "pod-defaults"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -12,10 +12,10 @@ output "provides" {
 output "requires" {
   value = {
     dashboard_links = "dashboard-links",
-    ingress = "ingress",
-    object_storage = "object-storage",
-    pod_defaults = "pod-defaults",
-    relational_db = "relational-db",
-    secrets = "secrets",
+    ingress         = "ingress",
+    object_storage  = "object-storage",
+    pod_defaults    = "pod-defaults",
+    relational_db   = "relational-db",
+    secrets         = "secrets",
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "mlflow-server"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -99,3 +99,10 @@ deps =
     ops>=2.3.0
     juju==3.0.4
 description = Run bundle test
+
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards


### PR DESCRIPTION
This commit adds the terraform/ directory to the root of the repository to host the Terraform module of this charm. This follows the standard set in CC006. For more information please also refer to canonical/argo-operators/pull/198.

Fixes #266

#### Testing instructions

1. Check the correctness of the module with `tox -e tflint`
2. Apply with `terraform apply -var "channel=latest/edge" -var "model_name=kubeflow" --auto-approve`
3. Wait for the charm to be deployed.

#### For reviewers

This module must expose all the information in the `metadata.yaml` of this charm, make sure you review it by comparing that file to the Tf files in this PR.