### PR TITLE
ci, docs: update to match standards for terraform

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,7 +55,6 @@ jobs:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
     with:
       charm-path: .
-      channel: latest/edge
       # Skipping the Terraform apply check as the mlflow-server goes to Waiting status
       # instead of the expected Blocked or Active. This is currently a limitation of the
       # Terraform re-usable workflows in canonical/charmed-kubeflow-workflows

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,9 +2,6 @@
 
 This is a Terraform module facilitating the deployment of the mlflow-server charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
-## Compatibility
-This terraform module is compatible with the mlflow-server charm 2.15/stable.
-
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 


### PR DESCRIPTION
This PR introduces the following changes based on a recent update to the team's standards for the terraform charm modules:

* docs: remove compatibility note

The latest standard for the terraform/ README.md is that the compatibility
    note can be obviated since the module at the branch is compatible with the
    charm in the same branch.

* ci: remove the channel from terraform checks

Since the default for deploying the charm is now set to latest/edge in
    the re-usable workflow, this is not required anymore.

Part of #266 (even though it was already closed)