### PR TITLE
fix(ci): Use actions-operator from `main`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -76,7 +76,7 @@ jobs:
         remove-docker-images: 'true'
     - uses: actions/checkout@v2
     - name: Setup operator environment
-      uses: charmed-kubernetes/actions-operator@1.1.0
+      uses: charmed-kubernetes/actions-operator@main
       with:
         juju-channel: 3.6/stable
         provider: microk8s


### PR DESCRIPTION
Old 1.1.0 verion presents bug documented in #307. Since the action is not publishing version, use it from `main`, as we do in the rest of charm repos.

Close #307

Note that documentation checks should be fixed in #309