### PR TITLE
fix(docs): update link to charmed kubernetes

### DIFF
--- a/docs/how-to/deploy-ck8s-aws.rst
+++ b/docs/how-to/deploy-ck8s-aws.rst
@@ -7,7 +7,7 @@ Deploy Charmed MLflow to Charmed Kubernetes on AWS
 |   MLflow  |    2    |
 +-----------+---------+
 
-This guide shows how to connect Juju to an existing `Charmed Kubernetes <https://ubuntu.com/kubernetes/charmed-k8s>`_ (CK8s) cluster and deploy the MLflow bundle on top of it.
+This guide shows how to connect Juju to an existing `Charmed Kubernetes <https://ubuntu.com/kubernetes/charmed-k8s/docs>`_ (CK8s) cluster and deploy the MLflow bundle on top of it.
 
 Prerequisites
 -------------

--- a/docs/how-to/integrate-ml-ckf-ck8s.rst
+++ b/docs/how-to/integrate-ml-ckf-ck8s.rst
@@ -7,7 +7,7 @@ Integrate Charmed MLflow with Charmed Kubeflow on Charmed Kubernetes
 |   MLflow  |    2    |
 +-----------+---------+
 
-In this guide, we will guide you through the process of integrating Charmed MLflow with Charmed Kubeflow on `Charmed Kubernetes <https://ubuntu.com/kubernetes/charmed-k8s>`_.
+In this guide, we will guide you through the process of integrating Charmed MLflow with Charmed Kubeflow on `Charmed Kubernetes <https://ubuntu.com/kubernetes/charmed-k8s/docs>`_.
 
 Prerequisites
 --------------


### PR DESCRIPTION
Update references to broken link for Charmed Kubernetes. This resolves the error seen below
```bash
(how-to/deploy-ck8s-aws: line   10) broken    https://ubuntu.com/kubernetes/charmed-k8s - 404 Client Error:  for url: https://ubuntu.com/kubernetes/charmed-k8s
```