### PR TITLE
refactor(tests): Move dependency charms to a separate file

### DIFF
--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -50,7 +50,7 @@ cffi==1.17.1
     #   argon2-cffi-bindings
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.9
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -119,7 +119,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -1,0 +1,30 @@
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+ISTIO_GATEWAY = CharmSpec(
+    charm="istio-gateway", channel="latest/edge", config={"kind": "ingress"}, trust=True
+)
+ISTIO_PILOT = CharmSpec(
+    charm="istio-pilot",
+    channel="latest/edge",
+    config={"default-gateway": "test-gateway"},
+    trust=True,
+)
+METACONTROLLER_OPERATOR = CharmSpec(
+    charm="metacontroller-operator", channel="latest/edge", trust=True
+)
+MINIO = CharmSpec(
+    charm="minio",
+    channel="latest/edge",
+    config={
+        "access-key": "minio",
+        "secret-key": "minio123",
+        "port": "9000",
+    },
+    trust=False,
+)
+MYSQL_K8S = CharmSpec(
+    charm="mysql-k8s", channel="8.0/stable", config={"profile": "testing"}, trust=True
+)
+RESOURCE_DISPATCHER = CharmSpec(charm="resource-dispatcher", channel="latest/edge", trust=True)


### PR DESCRIPTION
Move dependency charms deployed during tests to a separate file called
charms_dependencies.py. This enables programmatic access to them and
thus updating them centrally, probably with the use of `kfcicli`. This
uses the `CharmSpec` dataclass from chisme.

Ref canonical/bundle-kubeflow/issues/1256
