### PR TITLE
feat: Add `2.22` bundle for `mlflow`

### DIFF
--- a/docs/how-to/manage/upgrade/migrate-v21-v215.rst
+++ b/docs/how-to/manage/upgrade/migrate-v21-v215.rst
@@ -22,7 +22,7 @@ Charmed MLflow 2.15 requires:
 
 If you do not meet these requirements, please upgrade these dependencies. 
 See `MicroK8s upgrade <https://microk8s.io/docs/upgrading>`_ 
-and `Juju upgrade <https://juju.is/docs/juju/upgrade-your-juju-deployment>`_ respectively for more details.
+and `Juju upgrade <https://documentation.ubuntu.com/juju/3.6/tutorial/#upgrade>`_ respectively for more details.
 
 Upgrade MLflow bundle
 ----------------------

--- a/releases/2.22/edge/mlflow/bundle.yaml
+++ b/releases/2.22/edge/mlflow/bundle.yaml
@@ -4,7 +4,7 @@ docs: https://discourse.charmhub.io/t/mlflow-docs-index/10836
 applications:
   mlflow-minio:
     charm: minio
-    channel: latest/beta
+    channel: ckf-1.10/stable
     scale: 1
     trust: true
     _github_repo_name: minio-operator
@@ -19,7 +19,7 @@ applications:
     _github_dependency_repo_branch: main
   mlflow-server:
     charm: mlflow-server
-    channel: latest/beta
+    channel: 2.22/edge
     scale: 1
     trust: true
     _github_dependency_repo_name: mlflow-operator

--- a/releases/2.22/edge/mlflow/charmcraft.yaml
+++ b/releases/2.22/edge/mlflow/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle

--- a/releases/2.22/stable/mlflow/bundle.yaml
+++ b/releases/2.22/stable/mlflow/bundle.yaml
@@ -4,7 +4,7 @@ docs: https://discourse.charmhub.io/t/mlflow-docs-index/10836
 applications:
   mlflow-minio:
     charm: minio
-    channel: latest/beta
+    channel: ckf-1.10/stable
     scale: 1
     trust: true
     _github_repo_name: minio-operator
@@ -19,7 +19,7 @@ applications:
     _github_dependency_repo_branch: main
   mlflow-server:
     charm: mlflow-server
-    channel: latest/beta
+    channel: 2.22/stable
     scale: 1
     trust: true
     _github_dependency_repo_name: mlflow-operator

--- a/releases/2.22/stable/mlflow/charmcraft.yaml
+++ b/releases/2.22/stable/mlflow/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle

--- a/releases/latest/beta/mlflow/bundle.yaml
+++ b/releases/latest/beta/mlflow/bundle.yaml
@@ -4,7 +4,7 @@ docs: https://discourse.charmhub.io/t/mlflow-docs-index/10836
 applications:
   mlflow-minio:
     charm: minio
-    channel: latest/beta
+    channel: ckf-1.10/stable
     scale: 1
     trust: true
     _github_repo_name: minio-operator

--- a/releases/latest/edge/mlflow/bundle.yaml
+++ b/releases/latest/edge/mlflow/bundle.yaml
@@ -4,7 +4,7 @@ docs: https://discourse.charmhub.io/t/mlflow-docs-index/10836
 applications:
   mlflow-minio:
     charm: minio
-    channel: latest/edge
+    channel: ckf-1.10/stable
     scale: 1
     trust: true
     _github_repo_name: minio-operator

--- a/releases/latest/edge/mlflow/bundle.yaml
+++ b/releases/latest/edge/mlflow/bundle.yaml
@@ -4,7 +4,7 @@ docs: https://discourse.charmhub.io/t/mlflow-docs-index/10836
 applications:
   mlflow-minio:
     charm: minio
-    channel: ckf-1.9/stable
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: minio-operator

--- a/releases/latest/stable/mlflow/bundle.yaml
+++ b/releases/latest/stable/mlflow/bundle.yaml
@@ -4,7 +4,7 @@ docs: https://discourse.charmhub.io/t/mlflow-docs-index/10836
 applications:
   mlflow-minio:
     charm: minio
-    channel: ckf-1.9/stable
+    channel: latest/stable
     scale: 1
     trust: true
     _github_repo_name: minio-operator

--- a/releases/latest/stable/mlflow/bundle.yaml
+++ b/releases/latest/stable/mlflow/bundle.yaml
@@ -4,7 +4,7 @@ docs: https://discourse.charmhub.io/t/mlflow-docs-index/10836
 applications:
   mlflow-minio:
     charm: minio
-    channel: latest/stable
+    channel: ckf-1.10/stable
     scale: 1
     trust: true
     _github_repo_name: minio-operator

--- a/tox.ini
+++ b/tox.ini
@@ -110,15 +110,15 @@ commands =
 	tflint --chdir=terraform --recursive
 description = Check Terraform code against coding style standards
 
-[testenv:test_bundle_deployment-{2.15,latest}]
+[testenv:test_bundle_deployment-{2.22,latest}]
 commands = 
 	pytest -v --tb native --asyncio-mode=auto {[vars]tst_path}/integration/test_bundle_deployment.py --keep-models --log-cli-level=INFO -s {posargs}
 setenv = 
-	2.15: BUNDLE_PATH = "./releases/2.15/stable/mlflow/bundle.yaml"
-	2.15: KUBEFLOW_CHANNEL = 1.9/stable
-	2.15: RESOURCE_DISPATCHER_CHANNEL = 2.0/stable
+	2.22: BUNDLE_PATH = "./releases/2.22/stable/mlflow/bundle.yaml"
+	2.22: KUBEFLOW_CHANNEL = 1.10/stable
+	2.22: RESOURCE_DISPATCHER_CHANNEL = 2.0/stable
 	latest: BUNDLE_PATH = "./releases/latest/edge/mlflow/bundle.yaml"
-	latest: KUBEFLOW_CHANNEL = 1.9/stable
+	latest: KUBEFLOW_CHANNEL = 1.10/stable
 	latest: RESOURCE_DISPATCHER_CHANNEL = 2.0/stable
 deps = 
 	aiohttp
@@ -126,6 +126,6 @@ deps =
 	pytest-operator
 	tenacity
 	ops>=2.3.0
-	2.15: juju<4.0.0
+	2.22: juju<4.0.0
 	latest: juju<4.0.0
 description = Test bundle deployment


### PR DESCRIPTION
Closes #326

This PR:
- Creates the necessary files for the `2.22/edge`, `2.22/beta`, `2.22/stable` bundles
- Updates the bundles for `latest/edge` and `latest/stable` bundles.
- Update the `tox` bundle environments to the latest version.
- Replaces a broken link in the documentation (necessary for the documentation checks to pass).