### PR TITLE
chore: Update tutorials for `2.22`

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -49,6 +49,7 @@ reproducibility
 reST
 reStructuredText
 RTD
+snapcraft
 subdirectories
 subtree
 UI

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -40,6 +40,7 @@ NodePort
 observability
 OIDC
 OLM
+ons
 Permalink
 ReadMe
 readthedocs

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -86,7 +86,8 @@ redirects = {}
 # Links to ignore when checking links
 
 linkcheck_ignore = [
-    'http://127.0.0.1:8000'
+    'http://127.0.0.1:8000',
+    'https://matrix.to/#/#charmhub-mlops-kubeflow:ubuntu.com'
     ]
 
 ############################################################

--- a/docs/how-to/manage/upgrade/index.rst
+++ b/docs/how-to/manage/upgrade/index.rst
@@ -6,5 +6,6 @@ The following guides cover how to upgrade Charmed MLflow:
 .. toctree::
    :maxdepth: 1
 
+   migrate-v215-v222
    migrate-v21-v215
    migrate-v1-v2

--- a/docs/how-to/manage/upgrade/migrate-v21-v215.rst
+++ b/docs/how-to/manage/upgrade/migrate-v21-v215.rst
@@ -24,18 +24,18 @@ If you do not meet these requirements, please upgrade these dependencies.
 See `MicroK8s upgrade <https://microk8s.io/docs/upgrading>`_ 
 and `Juju upgrade <https://documentation.ubuntu.com/juju/3.6/tutorial/#upgrade>`_ respectively for more details.
 
-Upgrade MLflow bundle
-----------------------
+Upgrade MLflow
+---------------
 
-To upgrade the MLflow bundle charms from 2.11 to 2.15, run the following commands:
+To upgrade MLflow from 2.11 to 2.15, run the following commands:
 
 .. code-block:: bash
 
     juju refresh mlflow-minio --channel=ckf-1.9/stable
     juju refresh mlflow-server --channel=2.15/stable
 
-Upgrade resource dispatcher
---------------------------------------
+Upgrade Resource dispatcher
+----------------------------
 
 Only if you are running MLflow within Kubeflow, you must upgrade your `resource dispatcher <https://github.com/canonical/resource-dispatcher>`_ deployment. 
 

--- a/docs/how-to/manage/upgrade/migrate-v215-v222.rst
+++ b/docs/how-to/manage/upgrade/migrate-v215-v222.rst
@@ -1,0 +1,35 @@
+Upgrade from 2.15 to 2.22
+=========================
+
+This guide describes how to upgrade Charmed MLflow from version 2.15 to 2.22. 
+
+Requirements
+-------------
+
+* You have deployed MLflow version 2.15.
+* You have Command Line Interface (CLI) access to the machine where the Juju controller is deployed. All commands in this guide are executed from it.
+
+.. tip:: 
+    Before proceeding, you might want to backup MinIO data including your experiments and models. See :ref:`backup` for more details.
+
+Upgrade dependencies
+---------------------
+
+Charmed MLflow 2.22 requires:
+
+1. `MicroK8s <https://microk8s.io/>`_ version 1.29 or higher.
+2. `Juju <https://juju.is/>`_ version 3.6.
+
+If you do not meet these requirements, please upgrade these dependencies. 
+See `MicroK8s upgrade <https://microk8s.io/docs/upgrading>`_ 
+and `Juju upgrade <https://documentation.ubuntu.com/juju/3.6/tutorial/#upgrade>`_ respectively for more details.
+
+Upgrade MLflow bundle
+----------------------
+
+To upgrade the MLflow bundle charms from 2.15 to 2.22, run the following commands:
+
+.. code-block:: bash
+
+    juju refresh mlflow-minio --channel=ckf-1.10/stable
+    juju refresh mlflow-server --channel=2.22/stable

--- a/docs/how-to/manage/upgrade/migrate-v215-v222.rst
+++ b/docs/how-to/manage/upgrade/migrate-v215-v222.rst
@@ -24,10 +24,10 @@ If you do not meet these requirements, please upgrade these dependencies.
 See `MicroK8s upgrade <https://microk8s.io/docs/upgrading>`_ 
 and `Juju upgrade <https://documentation.ubuntu.com/juju/3.6/tutorial/#upgrade>`_ respectively for more details.
 
-Upgrade MLflow bundle
-----------------------
+Upgrade MLflow
+---------------
 
-To upgrade the MLflow bundle charms from 2.15 to 2.22, run the following commands:
+To upgrade MLflow from 2.15 to 2.22, run the following commands:
 
 .. code-block:: bash
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ Charmed MLflow is an open-source project that values its community. We warmly we
 * Read our `Code of conduct`_.
 * `Contribute`_ and `report bugs <https://github.com/canonical/mlflow-operator/issues/new/choose>`_.
 * Join the `Discourse forum`_.
-* `Talk to us`_.
+* `Talk to us on Matrix <https://matrix.to/#/#charmhub-mlops-kubeflow:ubuntu.com>`_.
 * Learn more about the `upstream project`_.
 
 .. toctree::

--- a/docs/tutorial/mlflow-kubeflow.rst
+++ b/docs/tutorial/mlflow-kubeflow.rst
@@ -6,9 +6,9 @@ Get started with Charmed MLflow and Kubeflow
 +-----------+---------+
 | Component | Version |
 +-----------+---------+
-|   MLflow  |   2.15  |
+|   MLflow  |   2.22  |
 +-----------+---------+
-|  Kubeflow |   1.9   |
+|  Kubeflow |   1.10  |
 +-----------+---------+
 
 This tutorial gets you started with Charmed MLflow integrated with `Charmed Kubeflow (CKF) <https://charmed-kubeflow.io/docs>`_.
@@ -18,14 +18,10 @@ Requirements
 
 This guide assumes you are deploying Kubeflow and MLflow on a public cloud Virtual Machine (VM) with the following specifications:
 
-- Runs Ubuntu 20.04 (focal) or later.
+- Runs Ubuntu 22.04 or later.
 - Has at least 4 cores, 32GB RAM and 200GB of disk space available.
 
-Also, your machine should meet the following requirements:
-
-- Has an SSH tunnel open to the VM with port forwarding and a SOCKS proxy. To see how to set this up, see `How to setup SSH VM Access <https://discourse.charmhub.io/t/how-to-setup-ssh-vm-access-with-port-forwarding/10872>`_.
-- Runs Ubuntu 20.04 (focal) or later.
-- Has a web browser installed e.g. Chrome / Firefox / Edge.
+Your machine should also have an SSH tunnel open to the VM with port forwarding and a SOCKS proxy. To see how to set this up, see `How to setup SSH VM Access <https://discourse.charmhub.io/t/how-to-setup-ssh-vm-access-with-port-forwarding/10872>`_.
 
 In the remainder of this tutorial, unless otherwise stated, it is assumed you will be running all command line operations on the VM, through the open SSH tunnel. It's also assumed you'll be using the web browser on your local machine to access the Kubeflow and MLflow dashboards.
 
@@ -36,32 +32,56 @@ Follow the steps in this tutorial to deploy MLflow on your VM: :doc:`mlflow`. Be
 
 .. _kubeflow-section:
 
-Deploy Kubeflow bundle
-----------------------
+Deploy the Kubeflow bundle
+--------------------------
 
-Let's deploy Charmed Kubeflow alongside MLflow. Run the following command to initiate the deployment:
+To deploy Kubeflow along MLflow, run:
 
 .. code-block:: bash
 
-   juju deploy kubeflow --trust  --channel=1.9/stable
+   juju deploy kubeflow --trust  --channel=1.10/stable
 
+Once the deployment is completed, you will see this message:
+
+.. code-block:: bash
+				
+	Deploy of bundle completed.
+
+.. note:: After the deployment, the bundle components need some time to initialise and establish communication with each other. This process may take up to 20 minutes.
+
+Check the status of the components with:
+
+.. code-block:: bash
+				
+	juju status
+
+Use the ``watch`` option to continuously track their status:
+
+.. code-block:: bash
+				
+	juju status --watch 5s
+
+CKF is ready when all the applications and units are in active status. During the configuration process, some of the components may momentarily change to a blocked or error state. This is an expected behaviour that should resolve as the bundle configures itself.
+	
 Set credentials for your Kubeflow deployment:
 
 .. code-block:: bash
 
    juju config dex-auth static-username=admin
    juju config dex-auth static-password=admin
-
+  
 Deploy Resource Dispatcher
 --------------------------
 
-Next, deploy the resource dispatcher. The resource dispatcher is an optional component which distributes Kubernetes objects related to MLflow credentials to all user namespaces in Kubeflow. This means that all your Kubeflow users can access the MLflow model registry from their namespaces. To deploy the dispatcher, run the following command:
+Resource dispatcher is an optional component which distributes Kubernetes objects related to MLflow credentials to all user namespaces in Kubeflow. This enables all Kubeflow users to access the MLflow model registry from their namespaces. To deploy resource dispatcher, run the following command:
 
 .. code-block:: bash
 
    juju deploy resource-dispatcher --channel 2.0/stable --trust
 
-This deploys the latest stable version of the dispatcher. See `Resource Dispatcher on GitHub <https://github.com/canonical/resource-dispatcher>`_ for more details. Now, relate the dispatcher to MLflow as follows:
+> See `Resource Dispatcher on GitHub <https://github.com/canonical/resource-dispatcher>`_ for more details.
+
+Then, relate the resource dispatcher to MLflow as follows:
 
 .. code-block:: bash
 
@@ -76,37 +96,10 @@ To deploy sorted MLflow models using KServe, create the required relations as fo
    juju integrate kserve-controller:service-accounts resource-dispatcher:service-accounts
    juju integrate kserve-controller:secrets resource-dispatcher:secrets
 
-Monitor The Deployment
-----------------------
-
-Now, at this point, we've deployed MLflow and Kubeflow and we've related them via the resource dispatcher. But that doesn't mean our system is ready yet: Juju will need to download charm data from CharmHub and the charms themselves will take some time to initialise.
-
-So, how do you know when all the charms are ready, then? You can do this using the ``juju status`` command. First, let's run a basic status command and review the output. Run the following command to print out the status of all the components of Juju:
-
-.. code-block:: bash
-
-   juju status
-
-Review the output for yourself. You should see some summary information, a list of Apps and associated information, and another list of Units and their associated information. Don't worry too much about what this all means for now. If you're interested in learning more about this command and its output, see the `Juju Status command <https://juju.is/docs/juju/juju-status>`_.
-
-The main thing we're interested in at this stage is the statuses of all the applications and units running through Juju. We want all the statuses to eventually become ``active``, indicating that the bundle is ready. Run the following command to keep a watch on the components which are not active yet:
-
-.. code-block:: bash
-
-   juju status --watch 5s
-
-This will periodically run a ``juju status`` command.
-
-Don't be surprised if some of the components' statuses change to ``blocked`` or ``error`` every now and then. This is expected behaviour, and these statuses should resolve by themselves as the bundle configures itself. However, if components remain stuck in the same error states, consult the troubleshooting steps below.
-
-.. note::
-
-   It can take up to 15 minutes for all charms to be downloaded and initialised.
-
 Integrate MLflow with Kubeflow Dashboard
 ----------------------------------------
 
-You can integrate your charmed MLflow deployment with the Kubeflow dashboard by running following commands:
+You can integrate the MLflow server with the Kubeflow dashboard by running:
 
 .. code-block:: bash
 
@@ -128,46 +121,39 @@ Now you should see the MLflow tab in the left sidebar of your Kubeflow dashboard
       microk8s kubectl -n kubeflow get svc istio-ingressgateway-workload -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
 
 
-Integrate MLflow with Notebook
-------------------------------
+Integrate MLflow with Notebooks
+-------------------------------
 
 In this section, you are going to create a Kubeflow notebook server and connect it to MLflow. 
 
-First, to be able to use MLflow credentials in your Kubeflow notebook, go to the MLflow dashboard at ``http://10.64.140.43.nip.io/`` 
-and use the username and password you configured in the previous :ref:`kubeflow-section` section.
-For example, ``admin`` and ``admin``.
+First, visit the MLflow dashboard at ``http://10.64.140.43.nip.io/`` and use the username and password you configured in the :ref:`kubeflow-section` section.
 
 Click on ``Start setup`` to setup the Kubeflow user for the first time.
 
 Select ``Finish`` to finish the process.
 
-Now a Kubernetes namespace is created for your user. 
-
-Now go back to the dashboard. From the left panel, choose ``Ǹotebooks``. 
+Now go back to the dashboard. From the left panel, choose ``Notebooks``. 
 Select ``+New Notebook``.
 
 At this point, name the notebook as you prefer, and choose the desired image and resource limits. 
 For example, you can use the following details:
 
 1. ``Name``: ``test-notebook``.
-2. Expand the *Custom Notebook* section and for ``image``, select ``kubeflownotebookswg/jupyter-tensorflow-full:v1.9.0``.
+2. Expand the *Custom Notebook* section and for ``image``, select ``kubeflownotebookswg/jupyter-tensorflow-full:v1.10.0``.
 
-Now, to allow your notebook server access to MLflow, you need to enable some configuration options. 
-Scroll down to ``Data Volumes -> Advanced options`` and from the ``Configurations`` dropdown, choose the following options:
+Now, to allow your notebook server access to MLflow, you need to enable some configuration options. Scroll down to ``Data Volumes -> Advanced options`` and from the ``Configurations`` dropdown, choose the following options:
 
 1. Allow access to Kubeflow pipelines.
 2. Allow access to MinIO.
 3. Allow access to MLflow.
 
-.. note:: Remember we related Kubeflow to MLflow earlier using the resource dispatcher? This is why we're seeing the MinIO and MLflow options in the dropdown!
+Clock on the ``Launch`` button to launch the notebook server.
 
-Great, that's all the configuration for the notebook server done. Hit the Launch button to launch the notebook server. Be patient, the notebook server will take a little while to initialise.
+.. note:: The notebook server may take a few minutes to initialise.
 
 When the notebook server is ready, you'll see it listed in the Notebooks table with a success status. At this point, select ``Connect`` to connect to the notebook server.
 
-When you connect to the notebook server, you'll be taken to the notebook environment in a new tab. Because of our earlier configurations, this environment is now connected to MLflow in the background. This means the notebooks we create here can access MLflow. Cool!
-
-To test this, create a new notebook and paste the following command into it, in a cell:
+To ensure that MLflow is accessible, create a new notebook and paste the following command into it, in a cell:
 
 .. code-block:: bash
 
@@ -175,23 +161,18 @@ To test this, create a new notebook and paste the following command into it, in 
 
 Run the cell. This will print out two environment variables ``MLFLOW_S3_ENDPOINT_URL`` and ``MLFLOW_TRACKING_URI``, confirming MLflow is indeed connected.
 
-Great, we've launched a notebook server that's connected to MLflow! Now let's upload some example notebooks to this server to see MLflow in practice.
-
 Run MLflow examples
 -------------------
 
 To run MLflow examples on your newly created notebook server, click on the source control icon in the leftmost navigation bar.
 
-From the menu, choose the ``Clone a Repository`` option.
+From the menu, choose the ``Clone a Repository`` option, and close the following repository: ``https://github.com/canonical/charmed-kubeflow-uats.git``.
 
-Now insert this repository address ``https://github.com/canonical/charmed-kubeflow-uats.git``.
+This clones the ``charmed-kubeflow-uats`` repository onto the notebook server. Enter the directory and choose the ``tests/notebooks`` sub-folder.
 
-This clones a whole ``charmed-kubeflow-uats`` repository onto the notebook server. The cloned repository is a folder on the server, with the same name as the remote repository. Go inside the folder and after that, choose the ``tests/notebooks`` sub-folder.
+You will see the following folders:
 
-There you find following folders:
-
-- ``mlflow-kserve``: demonstrates how to talk to MLflow and KServe from inside a notebook. This example trains a simple ML model, stores it in MLflow, deploys it with KServe from MLflow and runs inference.
+- ``mlflow-kserve``: demonstrates how to talk to MLflow and KServe from inside a notebook. This example trains a simple ML model, stores it in MLflow, deploys it with KServe from MLflow and runs an inference service.
 - ``mlflow-minio``: demonstrates how to talk to MinIO from inside a notebook. This example shows how you can use mounted MinIO secrets to talk to MinIO object store.
 - ``mlflow``: demonstrates how to talk to MLflow from inside a notebook. The example uses a simple regression model which is stored in the MLflow registry.
 
-Go ahead, try those notebooks out for yourself! You can run them cell by cell using the run button, or all at once using the double chevron `>>`.

--- a/docs/tutorial/mlflow-kubeflow.rst
+++ b/docs/tutorial/mlflow-kubeflow.rst
@@ -21,21 +21,25 @@ This guide assumes you are deploying Kubeflow and MLflow on a public cloud Virtu
 - Runs Ubuntu 22.04 or later.
 - Has at least 4 cores, 32GB RAM and 200GB of disk space available.
 
-Your machine should also have an SSH tunnel open to the VM with port forwarding and a SOCKS proxy. To see how to set this up, see `How to setup SSH VM Access <https://discourse.charmhub.io/t/how-to-setup-ssh-vm-access-with-port-forwarding/10872>`_.
+Your machine should also have an SSH tunnel open to the VM with port forwarding and a SOCKS proxy. 
+See `How to setup SSH VM Access <https://discourse.charmhub.io/t/how-to-setup-ssh-vm-access-with-port-forwarding/10872>`_ for more details.
 
-In the remainder of this tutorial, unless otherwise stated, it is assumed you will be running all command line operations on the VM, through the open SSH tunnel. It's also assumed you'll be using the web browser on your local machine to access the Kubeflow and MLflow dashboards.
+.. note:: 
+   This tutorial assumes you are running all commands on the VM, through the open SSH tunnel. 
+   Also that you are using the web browser on your local machine to access the Kubeflow and MLflow dashboards.
 
 Deploy MLflow
 -------------
 
-Follow the steps in this tutorial to deploy MLflow on your VM: :doc:`mlflow`. Before moving on with this tutorial, confirm that you can now access the MLflow UI on ``http://localhost:31380``.
+Follow the steps in this tutorial to deploy MLflow on your VM: :doc:`mlflow`. 
+Before moving on with this tutorial, confirm that you have access to the MLflow User Interface (UI) on ``http://localhost:31380``.
 
 .. _kubeflow-section:
 
-Deploy the Kubeflow bundle
---------------------------
+Deploy Kubeflow 
+----------------
 
-To deploy Kubeflow along MLflow, run:
+To deploy Kubeflow along MLflow, run the following:
 
 .. code-block:: bash
 
@@ -45,9 +49,11 @@ Once the deployment is completed, you will see this message:
 
 .. code-block:: bash
                 
-    Deploy of bundle completed.
+   Deploy of bundle completed.
 
-.. note:: After the deployment, the bundle components need some time to initialise and establish communication with each other. This process may take up to 20 minutes.
+.. note:: 
+   The bundle components need some time to initialise and establish communication with each other. 
+   This process may take up to 20 minutes.
 
 Check the status of the components with:
 
@@ -61,7 +67,8 @@ Use the ``watch`` option to continuously track their status:
                 
     juju status --watch 5s
 
-CKF is ready when all the applications and units are in active status. During the configuration process, some of the components may momentarily change to a blocked or error state. This is an expected behaviour that should resolve as the bundle configures itself.
+CKF is ready when all the applications and units are in active status. 
+During the configuration process, some of the components may momentarily change to a blocked or error state. This is an expected behaviour that should resolve as the bundle configures itself.
     
 Set credentials for your Kubeflow deployment:
 
@@ -70,18 +77,20 @@ Set credentials for your Kubeflow deployment:
    juju config dex-auth static-username=admin
    juju config dex-auth static-password=admin
   
-Deploy Resource Dispatcher
+Deploy Resource dispatcher
 --------------------------
 
-Resource dispatcher is an optional component which distributes Kubernetes objects related to MLflow credentials to all user namespaces in Kubeflow. This enables all Kubeflow users to access the MLflow model registry from their namespaces. To deploy resource dispatcher, run the following command:
+The Resource dispatcher operator is an optional component which distributes Kubernetes objects related to MLflow credentials to all user namespaces in Kubeflow. 
+This enables all Kubeflow users to access the MLflow model registry from their namespaces. 
+Deploy it as follows:
 
 .. code-block:: bash
 
    juju deploy resource-dispatcher --channel 2.0/stable --trust
 
-> See `Resource Dispatcher on GitHub <https://github.com/canonical/resource-dispatcher>`_ for more details.
+See `Resource Dispatcher <https://github.com/canonical/resource-dispatcher>`_ for more details.
 
-Then, relate the resource dispatcher to MLflow as follows:
+Then, relate the Resource dispatcher to MLflow as follows:
 
 .. code-block:: bash
 
@@ -96,7 +105,7 @@ To deploy sorted MLflow models using KServe, create the required relations as fo
    juju integrate kserve-controller:service-accounts resource-dispatcher:service-accounts
    juju integrate kserve-controller:secrets resource-dispatcher:secrets
 
-Integrate MLflow with Kubeflow Dashboard
+Integrate MLflow with Kubeflow dashboard
 ----------------------------------------
 
 You can integrate the MLflow server with the Kubeflow dashboard by running:
@@ -106,7 +115,7 @@ You can integrate the MLflow server with the Kubeflow dashboard by running:
    juju integrate mlflow-server:ingress istio-pilot:ingress
    juju integrate mlflow-server:dashboard-links kubeflow-dashboard:links
 
-Now you should see the MLflow tab in the left sidebar of your Kubeflow dashboard at:
+Now you should see the MLflow tab in the left-hand sidebar of your Kubeflow dashboard at:
 
 .. code-block:: bash
    
@@ -124,55 +133,62 @@ Now you should see the MLflow tab in the left sidebar of your Kubeflow dashboard
 Integrate MLflow with Notebooks
 -------------------------------
 
-In this section, you are going to create a Kubeflow notebook server and connect it to MLflow. 
+In this section, you are going to create a Kubeflow Notebook server and connect it to MLflow. 
 
-First, visit the MLflow dashboard at ``http://10.64.140.43.nip.io/`` and use the username and password you configured in the :ref:`kubeflow-section` section.
+1. Start by navigating to the MLflow dashboard at ``http://10.64.140.43.nip.io/``. 
+Use the username and password you configured in the :ref:`kubeflow-section` section.
 
-Click on ``Start setup`` to setup the Kubeflow user for the first time.
+2. Click on ``Start setup`` to setup the Kubeflow user for the first time and Select ``Finish`` to finish the process.
 
-Select ``Finish`` to finish the process.
-
-Now go back to the dashboard. From the left panel, choose ``Notebooks``. 
+3. Now go back to the dashboard. From the left panel, choose ``Notebooks``. 
 Select ``+New Notebook``.
 
-At this point, name the notebook as you prefer, and choose the desired image and resource limits. 
+At this point, name the Notebook and choose the desired image and resource limits. 
 For example, you can use the following details:
 
-1. ``Name``: ``test-notebook``.
-2. Expand the *Custom Notebook* section and select the ``jupyter-tensorflow-full`` image.
+* ``Name``: ``test-notebook``.
+* Expand the *Custom Notebook* section and select the ``jupyter-tensorflow-full`` image.
 
-Now, to allow your notebook server access to MLflow, you need to enable some configuration options. Scroll down to ``Data Volumes -> Advanced options`` and from the ``Configurations`` dropdown, choose the following options:
+Now, enable your Notebook server to access MLflow.
+Scroll down to ``Data Volumes -> Advanced options`` and from the ``Configurations`` dropdown, choose the following options:
 
-1. Allow access to Kubeflow pipelines.
-2. Allow access to MinIO.
-3. Allow access to MLflow.
+* Allow access to Kubeflow pipelines.
+* Allow access to MinIO.
+* Allow access to MLflow.
 
-Clock on the ``Launch`` button to launch the notebook server.
+Click on ``Launch`` to launch the Notebook server.
 
-.. note:: The notebook server may take a few minutes to initialise.
+.. note:: 
+   The notebook server may take a few minutes to initialise.
 
-When the notebook server is ready, you'll see it listed in the Notebooks table with a success status. At this point, select ``Connect`` to connect to the notebook server.
+Once the Notebook server is ready, you'll see it listed in the Notebooks table with a success status. 
+At this point, select ``Connect`` to connect to it.
 
-To ensure that MLflow is accessible, create a new notebook and paste the following command into it, in a cell:
+To ensure that MLflow is accessible, create a new notebook and add a cell with the following command:
 
 .. code-block:: bash
 
    !printenv | grep MLFLOW
 
-Run the cell. This will print out two environment variables ``MLFLOW_S3_ENDPOINT_URL`` and ``MLFLOW_TRACKING_URI``, confirming MLflow is indeed connected.
+Run the cell. 
+This will print out ``MLFLOW_S3_ENDPOINT_URL`` and ``MLFLOW_TRACKING_URI`` variables, confirming MLflow is connected.
 
 Run MLflow examples
 -------------------
 
-To run MLflow examples on your newly created notebook server, click on the source control icon in the leftmost navigation bar.
+To run MLflow examples on your newly created Notebook server, click on the source control icon in the leftmost navigation bar.
 
-From the menu, choose the ``Clone a Repository`` option, and close the following repository: ``https://github.com/canonical/charmed-kubeflow-uats.git``.
+From the menu, choose ``Clone a Repository``, and clone the following repository: ``https://github.com/canonical/charmed-kubeflow-uats.git``.
 
-This clones the ``charmed-kubeflow-uats`` repository onto the notebook server. Enter the directory and choose the ``tests/notebooks`` sub-folder.
+This clones the ``charmed-kubeflow-uats`` repository onto the Notebook server. 
+Enter the directory and navigate to the ``tests/notebooks`` sub-folder.
 
 You will see the following folders:
 
-- ``mlflow-kserve``: demonstrates how to talk to MLflow and KServe from inside a notebook. This example trains a simple ML model, stores it in MLflow, deploys it with KServe from MLflow and runs an inference service.
-- ``mlflow-minio``: demonstrates how to talk to MinIO from inside a notebook. This example shows how you can use mounted MinIO secrets to talk to MinIO object store.
-- ``mlflow``: demonstrates how to talk to MLflow from inside a notebook. The example uses a simple regression model which is stored in the MLflow registry.
+* ``mlflow-kserve``: Demonstrates how to interact with MLflow and KServe from inside a notebook. This example trains a simple ML model, stores it in MLflow, deploys it with KServe from MLflow, and runs an inference service.
+
+* ``mlflow-minio``: Demonstrates how to interact with MinIO from inside a notebook. This example shows how to use mounted MinIO secrets to access the MinIO object store.
+
+* ``mlflow``: Demonstrates how to interact with MLflow from inside a notebook. This example uses a simple regression model that is stored in the MLflow registry.
+
 

--- a/docs/tutorial/mlflow-kubeflow.rst
+++ b/docs/tutorial/mlflow-kubeflow.rst
@@ -44,25 +44,25 @@ To deploy Kubeflow along MLflow, run:
 Once the deployment is completed, you will see this message:
 
 .. code-block:: bash
-				
-	Deploy of bundle completed.
+                
+    Deploy of bundle completed.
 
 .. note:: After the deployment, the bundle components need some time to initialise and establish communication with each other. This process may take up to 20 minutes.
 
 Check the status of the components with:
 
 .. code-block:: bash
-				
-	juju status
+                
+    juju status
 
 Use the ``watch`` option to continuously track their status:
 
 .. code-block:: bash
-				
-	juju status --watch 5s
+                
+    juju status --watch 5s
 
 CKF is ready when all the applications and units are in active status. During the configuration process, some of the components may momentarily change to a blocked or error state. This is an expected behaviour that should resolve as the bundle configures itself.
-	
+    
 Set credentials for your Kubeflow deployment:
 
 .. code-block:: bash

--- a/docs/tutorial/mlflow-kubeflow.rst
+++ b/docs/tutorial/mlflow-kubeflow.rst
@@ -139,7 +139,7 @@ At this point, name the notebook as you prefer, and choose the desired image and
 For example, you can use the following details:
 
 1. ``Name``: ``test-notebook``.
-2. Expand the *Custom Notebook* section and for ``image``, select ``kubeflownotebookswg/jupyter-tensorflow-full:v1.10.0``.
+2. Expand the *Custom Notebook* section and select the ``jupyter-tensorflow-full`` image.
 
 Now, to allow your notebook server access to MLflow, you need to enable some configuration options. Scroll down to ``Data Volumes -> Advanced options`` and from the ``Configurations`` dropdown, choose the following options:
 

--- a/docs/tutorial/mlflow.rst
+++ b/docs/tutorial/mlflow.rst
@@ -7,7 +7,7 @@ This guide describes how you can get started with Charmed MLflow, from deploying
 
 Charmed MLflow is a `charm bundle <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/bundle/>`_ that facilitates a quick deployment of 
 `MLflow <https://mlflow.org/>`_, an open-source platform, used for managing machine learning workflows,
-including experiment tracking, model registry, model management and code reproducibility..
+including experiment tracking, model registry, model management and code reproducibility.
 
 Requirements
 -------------
@@ -174,7 +174,7 @@ To access your Charmed MLflow deployment, navigate to the following URL:
 This will take you to the MLflow User Interface (UI).
 
 .. note:: 
-   by default Charmed MLflow creates a `NodePort <https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport>`_ on port 31380 where you can access the MLflow UI.
+   By default, Charmed MLflow creates a `NodePort <https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport>`_ on port 31380, which you can use to access the MLflow UI.
 
 
 

--- a/docs/tutorial/mlflow.rst
+++ b/docs/tutorial/mlflow.rst
@@ -100,8 +100,9 @@ Run the following command to add a model named ``kubeflow``:
 
 .. note:: The model name here can be anything. In this tutorial, ``kubeflow`` is being used because you may want to deploy MLflow along with Kubeflow, and in that case, the model name must be ``kubeflow``.
 
-Deploy MLflow bundle
---------------------
+Deploy MLflow
+--------------
+
 MicroK8s uses ``inotify`` to interact with the file system. 
 This may lead to situations where large MicroK8s deployments exceed the default ``inotify`` limits. 
 To increase the limits, run the following commands:
@@ -149,6 +150,18 @@ You can also use the ``watch`` option to continuously monitor the statuses:
 During the deployment process, some of the components statuses may momentarily change to blocked or error state. 
 This is an expected behaviour, and these statuses should resolve by themselves as the bundle configures.
 
+Object storage
+~~~~~~~~~~~~~~~
+
+Charmed MLflow uses MinIO as the object storage. 
+Get your credentials by running the following command:
+
+.. code-block:: bash
+
+   juju run mlflow-server/0 get-minio-credentials
+
+This action returns ``secret-key`` and ``secret-access-key``.
+
 Access your deployment
 -----------------------
 
@@ -160,17 +173,8 @@ To access your Charmed MLflow deployment, navigate to the following URL:
 
 This will take you to the MLflow User Interface (UI).
 
-.. note:: by default Charmed MLflow creates a `NodePort <https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport>`_ on port 31380 where you can access the MLflow UI.
+.. note:: 
+   by default Charmed MLflow creates a `NodePort <https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport>`_ on port 31380 where you can access the MLflow UI.
 
 
-Reference: Object storage credentials
--------------------------------------
 
-Charmed MLflow uses `MinIO <https://charmhub.io/minio>`_ as the object storage. 
-Get your credentials by running the following command:
-
-.. code-block:: bash
-
-   juju run mlflow-server/0 get-minio-credentials
-
-This action returns ``secret-key`` and ``secret-access-key``.

--- a/docs/tutorial/mlflow.rst
+++ b/docs/tutorial/mlflow.rst
@@ -88,7 +88,7 @@ Next, we'll need to add a model for Kubeflow to the controller. Run the followin
 
 Deploy MLflow bundle
 --------------------
-MicroK8s uses inotify to interact with the file system. Large Microk8s deployment sometimes exceed the default ``inotify`` limits. To increase the limits, run the following commands:
+MicroK8s uses ``inotify`` to interact with the file system. Large MicroK8s deployment sometimes exceed the default ``inotify`` limits. To increase the limits, run the following commands:
 
 .. code-block:: bash
 

--- a/docs/tutorial/mlflow.rst
+++ b/docs/tutorial/mlflow.rst
@@ -89,7 +89,7 @@ Now, run the following command to deploy a Juju controller to MicroK8s:
 
 .. note:: The controller may take a few minutes to deploy.
 
-The controller is the Juju's agent, running on K8s, which can be used to deploy and control MLflow's components.
+The controller is the Juju agent, running on K8s, which can be used to deploy and control MLflow's components.
 
 Next, you need to add a model for Kubeflow to the controller. 
 Run the following command to add a model named ``kubeflow``:

--- a/docs/tutorial/mlflow.rst
+++ b/docs/tutorial/mlflow.rst
@@ -33,14 +33,14 @@ For MicroK8s to work without having to use ``sudo`` for every command, it create
 For deploying Charmed MLflow, additional features from the default ones that come with MicroK8s are needed. These can be installed as MicroK8s add-ons. Run the following command to enable them:
 
 .. code-block:: bash
-	sudo microk8s enable dns hostpath-storage metallb:10.64.140.43-10.64.140.49 rbac
+    sudo microk8s enable dns hostpath-storage metallb:10.64.140.43-10.64.140.49 rbac
 
 > See More : `MicroK8s | How to use addons <https://microk8s.io/docs/addons>`_
 
 To confirm that all add-ons are successfully enabled, check the MicroK8s status as follows:
 
 .. code-block:: bash
-	microk8s status
+    microk8s status
 
 .. note:: The add-ons configuration may take a few minutes to complete before they are listed as enabled.
 
@@ -98,9 +98,9 @@ MicroK8s uses inotify to interact with the file system. Large Microk8s deploymen
 If you want these commands to persist across machine restarts, add these lines to ``/etc/sysctl.conf``:
 
 .. code-block:: bash
-				
-	fs.inotify.max_user_instances=1280
-	fs.inotify.max_user_watches=655360
+                
+    fs.inotify.max_user_instances=1280
+    fs.inotify.max_user_watches=655360
    
 
 To deploy the MLflow bundle, run the following command:

--- a/docs/tutorial/mlflow.rst
+++ b/docs/tutorial/mlflow.rst
@@ -3,11 +3,11 @@
 Get started with Charmed MLflow
 ==================================
 
-`MLflow <https://mlflow.org/>`_ is an open-source platform, used for managing machine learning workflows. It has four primary functions that include experiment tracking, model registry, model management and code reproducibility.
+This guide describes how you can get started with Charmed MLflow, from deploying to accessing it. It is intended for system administrators and end users.
 
-Charmed MLflow is a `charm bundle <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/bundle/>`_ that enables the deployment of MLflow quickly and easily with just a few commands.
-
-This tutorial describes how to deploy Charmed MLflow using the `Juju <https://juju.is/>`_ CLI tool and a local `MicroK8s <https://microk8s.io/>`_ cloud.
+Charmed MLflow is a `charm bundle <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/bundle/>`_ that facilitates a quick deployment of 
+`MLflow <https://mlflow.org/>`_, an open-source platform, used for managing machine learning workflows,
+including experiment tracking, model registry, model management and code reproducibility..
 
 Requirements
 -------------
@@ -15,9 +15,18 @@ Requirements
 * Ubuntu 22.04 or later.
 * A host machine with at least 50GB of disk space available.
 
-Install and prepare MicroK8s
-----------------------------
-MicroK8s can be installed from a snap package. The published snap maintains different ``channels`` for different releases of Kubernetes.
+Install and configure dependencies 
+----------------------------------
+
+Charmed MLflow relies on:
+
+- Kubernetes (K8s). This tutorial uses MicroK8s, an open-source zero-ops lightweight distribution of Kubernetes, to run a K8s cluster.
+- A software orchestration engine. This tutorial uses `Juju <https://juju.is/>`_ to deploy and manage the Charmed MLflow components.
+
+MicroK8s
+~~~~~~~~~
+You can install MicroK8s from a `snap package <https://snapcraft.io/>`. 
+The published snap maintains different ``channels`` for different releases of Kubernetes.
 
 .. code-block:: bash
 
@@ -30,24 +39,29 @@ For MicroK8s to work without having to use ``sudo`` for every command, it create
    sudo usermod -a -G microk8s $USER
    newgrp microk8s
 
-For deploying Charmed MLflow, additional features from the default ones that come with MicroK8s are needed. These can be installed as MicroK8s add-ons. Run the following command to enable them:
+For deploying Charmed MLflow, you need additional features from the MicroK8s' default ones. 
+These can be installed as MicroK8s add-ons. 
+Run the following command to enable them:
 
 .. code-block:: bash
-    sudo microk8s enable dns hostpath-storage metallb:10.64.140.43-10.64.140.49 rbac
+   
+   sudo microk8s enable dns hostpath-storage metallb:10.64.140.43-10.64.140.49 rbac
 
-> See More : `MicroK8s | How to use addons <https://microk8s.io/docs/addons>`_
+See `How to use MicroK8s add-ons <https://microk8s.io/docs/addons>`_ for more details.
 
-To confirm that all add-ons are successfully enabled, check the MicroK8s status as follows:
+To confirm that all add-ons are successfully enabled, check MicroK8s' status as follows:
 
 .. code-block:: bash
-    microk8s status
+   
+   microk8s status
 
 .. note:: The add-ons configuration may take a few minutes to complete before they are listed as enabled.
 
+Juju
+~~~~~
 
-Install Juju
-------------
-`Juju <https://juju.is/>`_ is an operation Lifecycle manager (OLM) for clouds, bare metal or Kubernetes. We will be using it to deploy and manage the components which make up Kubeflow.
+Juju is an operation Lifecycle manager (OLM) for clouds, bare metal or K8s. 
+You will use it to deploy and manage the components which make up Charmed MLflow.
 
 To install Juju from snap, run this command:
 
@@ -67,7 +81,7 @@ As a next step, configure MicroK8s to work properly with Juju by running:
 
    microk8s config | juju add-k8s my-k8s --client
 
-Now, run the following command to deploy a Juju controller to the Kubernetes we set up with MicroK8s:
+Now, run the following command to deploy a Juju controller to MicroK8s:
 
 .. code-block:: bash
 
@@ -75,9 +89,10 @@ Now, run the following command to deploy a Juju controller to the Kubernetes we 
 
 .. note:: The controller may take a few minutes to deploy.
 
-The controller is the agent of Juju, running on Kubernetes, which can be used to deploy and control the MLflow components.
+The controller is the Juju's agent, running on K8s, which can be used to deploy and control MLflow's components.
 
-Next, we'll need to add a model for Kubeflow to the controller. Run the following command to add a model called ``kubeflow``:
+Next, you need to add a model for Kubeflow to the controller. 
+Run the following command to add a model named ``kubeflow``:
 
 .. code-block:: bash
 
@@ -85,10 +100,11 @@ Next, we'll need to add a model for Kubeflow to the controller. Run the followin
 
 .. note:: The model name here can be anything. In this tutorial, ``kubeflow`` is being used because you may want to deploy MLflow along with Kubeflow, and in that case, the model name must be ``kubeflow``.
 
-
 Deploy MLflow bundle
 --------------------
-MicroK8s uses ``inotify`` to interact with the file system. Large MicroK8s deployment sometimes exceed the default ``inotify`` limits. To increase the limits, run the following commands:
+MicroK8s uses ``inotify`` to interact with the file system. 
+This may lead to situations where large MicroK8s deployments exceed the default ``inotify`` limits. 
+To increase the limits, run the following commands:
 
 .. code-block:: bash
 
@@ -103,7 +119,7 @@ If you want these commands to persist across machine restarts, add these lines t
     fs.inotify.max_user_watches=655360
    
 
-To deploy the MLflow bundle, run the following command:
+Deploy now the MLflow bundle as follows:
 
 .. code-block:: bash
 
@@ -117,39 +133,44 @@ Once the deployment is completed, you will see a message such as the following:
    
    Deploy of bundle completed.
 
-You can use the following command to check the status of all the model components:
+You can use the following command to check the status of all model components:
 
 .. code-block:: bash
 
    juju status
 
-The deployment is ready when the statuses of all the applications and the units in the bundle have an active status. You can also use the ``watch`` option to continuously watch the status of the model:
+The deployment is ready when all the applications and units in the bundle are in active status. 
+You can also use the ``watch`` option to continuously monitor the statuses:
 
 .. code-block:: bash
 
    juju status --watch 5s
 
-During the deployment process, some of the components statuses may momentarily change to blocked or error state. This is an expected behaviour, and these statuses should resolve by themselves as the bundle configures.
+During the deployment process, some of the components statuses may momentarily change to blocked or error state. 
+This is an expected behaviour, and these statuses should resolve by themselves as the bundle configures.
 
-Access MLflow
--------------
-To access MLflow, visit the following URL in your web browser:
+Access your deployment
+-----------------------
+
+To access your Charmed MLflow deployment, navigate to the following URL:
 
 .. code-block:: bash
 
    http://localhost:31380/
 
-This will take you to the MLflow UI.
+This will take you to the MLflow User Interface (UI).
 
 .. note:: by default Charmed MLflow creates a `NodePort <https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport>`_ on port 31380 where you can access the MLflow UI.
 
 
 Reference: Object storage credentials
 -------------------------------------
-To use MLflow you need to have credentials to the object storage. The aforementioned bundle comes with MinIO. To get the ``MinIO`` credentials run the following command:
+
+Charmed MLflow uses `MinIO <https://charmhub.io/minio>`_ as the object storage. 
+Get your credentials by running the following command:
 
 .. code-block:: bash
 
    juju run mlflow-server/0 get-minio-credentials
 
-This action will output ``secret-key`` and ``secret-access-key``.
+This action returns ``secret-key`` and ``secret-access-key``.


### PR DESCRIPTION
Closes #332

This PR:
- Updates the 2 main tutorial pages for `2.22`.
- Creates a new migration guide for `2.15` to `2.22`.

For https://documentation.ubuntu.com/charmed-mlflow/tutorial/mlflow/:
- Removed the `Component` table in the beginning (I don't think it makes much sense since it is only one component).
- Updated versions of Juju, microk8s, mlflow-bundle.
- Tried to remove the conversationalist style from the previous writers.
- Changed the installation of `microk8s` from `strict` to the `classic` confinement. This is similar to what we already do with `kubflow`.
- Tried to match the style we use in https://charmed-kubeflow.io/docs/get-started.

For https://documentation.ubuntu.com/charmed-mlflow/tutorial/mlflow-kubeflow/:
- Update the Ubuntu base requirement and removed the requirement for a browser
- Updated versions of `kubeflow`.
- Tried to remove the conversationalist style from the previous writers.
- Removed "Monitor deployment" section which was redundant.
- Tried to match the style we use in https://charmed-kubeflow.io/docs/get-started.
- Updated the notebook image name to be version independent so that we don't have to update it every time.

Note that the word "ons" is added to the `.wordlist.txt` so that the word `add-ons` is considered correct.