### PR TITLE
fix: Add README.md to bundles

### DIFF
--- a/releases/2.22/edge/mlflow/README.md
+++ b/releases/2.22/edge/mlflow/README.md
@@ -1,0 +1,17 @@
+# MLflow Operators
+
+## Introduction
+
+Charmed MLflow is a full set of Kubernetes operators to deliver the [MLflow](https://mlflow.org/), for easy operations anywhere, from workstations to on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+## Documentation
+
+Read the [Start with MLflow guide][docs] for more information.
+
+[docs]: https://discourse.charmhub.io/t/get-started-with-charmed-mlflow-v2/10693

--- a/releases/2.22/stable/mlflow/README.md
+++ b/releases/2.22/stable/mlflow/README.md
@@ -1,0 +1,17 @@
+# MLflow Operators
+
+## Introduction
+
+Charmed MLflow is a full set of Kubernetes operators to deliver the [MLflow](https://mlflow.org/), for easy operations anywhere, from workstations to on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+## Documentation
+
+Read the [Start with MLflow guide][docs] for more information.
+
+[docs]: https://discourse.charmhub.io/t/get-started-with-charmed-mlflow-v2/10693

--- a/releases/latest/beta/mlflow/README.md
+++ b/releases/latest/beta/mlflow/README.md
@@ -1,0 +1,17 @@
+# MLflow Operators
+
+## Introduction
+
+Charmed MLflow is a full set of Kubernetes operators to deliver the [MLflow](https://mlflow.org/), for easy operations anywhere, from workstations to on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+## Documentation
+
+Read the [Start with MLflow guide][docs] for more information.
+
+[docs]: https://discourse.charmhub.io/t/get-started-with-charmed-mlflow-v2/10693

--- a/releases/latest/edge/mlflow/README.md
+++ b/releases/latest/edge/mlflow/README.md
@@ -1,0 +1,17 @@
+# MLflow Operators
+
+## Introduction
+
+Charmed MLflow is a full set of Kubernetes operators to deliver the [MLflow](https://mlflow.org/), for easy operations anywhere, from workstations to on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+## Documentation
+
+Read the [Start with MLflow guide][docs] for more information.
+
+[docs]: https://discourse.charmhub.io/t/get-started-with-charmed-mlflow-v2/10693

--- a/releases/latest/stable/mlflow/README.md
+++ b/releases/latest/stable/mlflow/README.md
@@ -1,0 +1,17 @@
+# MLflow Operators
+
+## Introduction
+
+Charmed MLflow is a full set of Kubernetes operators to deliver the [MLflow](https://mlflow.org/), for easy operations anywhere, from workstations to on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+## Documentation
+
+Read the [Start with MLflow guide][docs] for more information.
+
+[docs]: https://discourse.charmhub.io/t/get-started-with-charmed-mlflow-v2/10693


### PR DESCRIPTION
This PR adds README.md files to the newest bundles in the `2.22` and `latest` directories.

Otherwise, we may receive the following error while trying to deploy the bundle
```
ERROR archive file "README.md" not found
```