### PR TITLE
Quick Fix for issue #359

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,3 +37,7 @@ options:
     description: Deploy the NodePort service for MLFlow
     type: boolean
     default: true
+  s3_addressing_style:
+    description: The addressing style for the s3 storage. Has to be "virtual" or "path".
+    type: string
+    default: virtual

--- a/src/charm.py
+++ b/src/charm.py
@@ -446,6 +446,7 @@ class MlflowCharm(CharmBase):
             s3_wrapper = S3BucketWrapper(
                 access_key=object_storage_data["access-key"],
                 secret_access_key=object_storage_data["secret-key"],
+                s3_addressing_style=self.model.config["s3_addressing_style"],
                 s3_service=f"{object_storage_data['service']}.{object_storage_data['namespace']}",
                 s3_port=object_storage_data["port"],
             )

--- a/src/services/s3.py
+++ b/src/services/s3.py
@@ -12,7 +12,7 @@ class S3BucketWrapper:
     """Wrapper for basic accessing and validating of S3 Buckets."""
 
     def __init__(
-        self, access_key: str, secret_access_key: str, s3_service: str, s3_port: Union[str, int]
+        self, access_key: str, secret_access_key: str, s3_addressing_style: str, s3_service: str, s3_port: Union[str, int]
     ):
         """Initialize S3 Bucket Wrapper.
 
@@ -24,6 +24,7 @@ class S3BucketWrapper:
 
         self.access_key: str = access_key
         self.secret_access_key: str = secret_access_key
+        self.s3_addressing_style: str = s3_addressing_style
         self.s3_service: str = s3_service
         self.s3_port: str = str(s3_port)
 
@@ -65,11 +66,15 @@ class S3BucketWrapper:
         if self._client:
             return self._client
         else:
+            if self.s3_addressing_style not in ("path", "virtual"):
+                self.s3_addressing_style = "virtual"
+
             self._client = boto3.client(
                 "s3",
                 endpoint_url=self.s3_url,
                 aws_access_key_id=self.access_key,
                 aws_secret_access_key=self.secret_access_key,
+                config=botocore.config.Config(s3={"addressing_style": self.s3_addressing_style})
             )
             return self._client
 


### PR DESCRIPTION
Quick fix for issue #359. Allows the user to set the addressing style for the used S3-store via juju config s3_addressing_style. Default is "virtual", the other option is "path".
"Path" is only needed if you use an S3-store that cannot handle the "virtual"-addressing style (e.g. Cloudian). Many stores, like AWS, can handle both styles. 

