### PR TITLE
docs: Configure slug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ html_theme_options = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = 'charmed-mlflow'
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/

--- a/docs/how-to/manage/upgrade/migrate-v21-v215.rst
+++ b/docs/how-to/manage/upgrade/migrate-v21-v215.rst
@@ -22,7 +22,7 @@ Charmed MLflow 2.15 requires:
 
 If you do not meet these requirements, please upgrade these dependencies. 
 See `MicroK8s upgrade <https://microk8s.io/docs/upgrading>`_ 
-and `Get started with Juju <https://documentation.ubuntu.com/juju/3.6/tutorial>`_ respectively for more details.
+and `Juju upgrade <https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#upgrade-your-deployment>`_ respectively for more details.
 
 Upgrade MLflow
 ---------------

--- a/docs/how-to/manage/upgrade/migrate-v21-v215.rst
+++ b/docs/how-to/manage/upgrade/migrate-v21-v215.rst
@@ -22,7 +22,7 @@ Charmed MLflow 2.15 requires:
 
 If you do not meet these requirements, please upgrade these dependencies. 
 See `MicroK8s upgrade <https://microk8s.io/docs/upgrading>`_ 
-and `Juju upgrade <https://documentation.ubuntu.com/juju/3.6/tutorial/#upgrade>`_ respectively for more details.
+and `Get started with Juju <https://documentation.ubuntu.com/juju/3.6/tutorial>`_ respectively for more details.
 
 Upgrade MLflow
 ---------------

--- a/docs/how-to/manage/upgrade/migrate-v215-v222.rst
+++ b/docs/how-to/manage/upgrade/migrate-v215-v222.rst
@@ -22,7 +22,7 @@ Charmed MLflow 2.22 requires:
 
 If you do not meet these requirements, please upgrade these dependencies. 
 See `MicroK8s upgrade <https://microk8s.io/docs/upgrading>`_ 
-and `Get started with Juju <https://documentation.ubuntu.com/juju/3.6/tutorial>`_ respectively for more details.
+and `Juju upgrade <https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#upgrade-your-deployment>`_ respectively for more details.
 
 Upgrade MLflow
 ---------------

--- a/docs/how-to/manage/upgrade/migrate-v215-v222.rst
+++ b/docs/how-to/manage/upgrade/migrate-v215-v222.rst
@@ -22,7 +22,7 @@ Charmed MLflow 2.22 requires:
 
 If you do not meet these requirements, please upgrade these dependencies. 
 See `MicroK8s upgrade <https://microk8s.io/docs/upgrading>`_ 
-and `Juju upgrade <https://documentation.ubuntu.com/juju/3.6/tutorial/#upgrade>`_ respectively for more details.
+and `Get started with Juju <https://documentation.ubuntu.com/juju/3.6/tutorial>`_ respectively for more details.
 
 Upgrade MLflow
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,5 +54,5 @@ Charmed MLflow is an open-source project that values its community.
 Contributions, suggestions, fixes, and constructive feedback are welcome from everyone.
 
 * Read our `Code of conduct`_.
-* `Contribute <https://github.com/canonical/mlflow-operator>`_ and `report bugs <https://github.com/canonical/mlflow-operator/issues/new/choose>`_.
+* `Contribute <https://github.com/canonical/mlflow-operator>`_ and `report bugs <https://github.com/canonical/mlflow-operator/issues>`_.
 * Talk to us on `Matrix`_.


### PR DESCRIPTION
This is required for the `notfound` extension to function correctly and render a valid page on encountering a 404 error.

Addresses the issue raised [here](https://chat.canonical.com/canonical/pl/z435uy16k3yp8x6z3zhuamupky) in the mm docs channel.