### PR TITLE
fix: Change dump-charm-debug-artifacts to run on failure

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Collect charm debug artifacts
       uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-      if: always()
+      if: failure()
 
     # On failure, capture debugging resources      
     - name: Get all


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1341