### PR TITLE
[Copilot test dont merge] Upgrade MLflow server to version 3.5.1

### DIFF
--- a/UPGRADE_PLAN.md
+++ b/UPGRADE_PLAN.md
@@ -1,0 +1,14 @@
+# MLflow 3.5.1 Upgrade Plan
+
+This file tracks the upgrade of MLflow from 2.22.0 to 3.5.1.
+
+## Tasks
+- [ ] Update metadata.yaml with new Docker image: `docker.io/misohu/mlflow:3.5.1`
+- [ ] Update pyproject.toml MLflow dependency to 3.5.1
+- [ ] Regenerate poetry.lock
+- [ ] Test compatibility
+
+## Docker Image
+Using: `misohu/mlflow:3.5.1`
+
+This file will be removed after upgrade completion.


### PR DESCRIPTION
## Description

This PR upgrades MLflow server from version 2.22.0 to 3.5.1 using the custom Docker image `misohu/mlflow:3.5.1`.

## Changes Required

- [ ] Update `metadata.yaml` to use new Docker image: `docker.io/misohu/mlflow:3.5.1`
- [ ] Update `pyproject.toml` MLflow dependency from `2.22.0` to `3.5.1`
- [ ] Update poetry.lock file with new dependencies
- [ ] Review and update any version-specific configurations
- [ ] Test compatibility with existing integrations

## Related Issue

Addresses #381 - Update MLflow server to major version 3.x

## Files to Update

1. **metadata.yaml** - Change upstream-source from `docker.io/charmedkubeflow/mlflow:2.22.0-2db94f5` to `docker.io/misohu/mlflow:3.5.1`
2. **pyproject.toml** - Update mlflow dependency from `"==2.22.0"` to `"==3.5.1"`
3. **poetry.lock** - Regenerate with new dependency versions
4. Any configuration files that reference version 2.22.0

## Testing

- [ ] Integration tests with MySQL database
- [ ] Integration tests with MinIO object storage  
- [ ] Integration tests with Kubeflow
- [ ] Verify existing experiments and models remain accessible
- [ ] Verify Prometheus metrics endpoint
- [ ] Test charm upgrade path

## Docker Image Details

Using custom MLflow 3.5.1 image: `misohu/mlflow:3.5.1`

---

**Note**: This PR will be implemented by GitHub Copilot code agent.