### PR TITLE
fix: pin terraform version to lower than 1.0.0

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
Resolves the CI issues we are seeing with Terraform, due to bump to 1.0.0