### PR TITLE
fix: mark secrets and pod-defaults as optional in metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -108,7 +108,9 @@ requires:
       all routes will have authentication applied to them.
   secrets:
     interface: kubernetes_manifest
+    optional: true
   pod-defaults:
+    optional: true
     interface: kubernetes_manifest
   logging:
     interface: loki_push_api


### PR DESCRIPTION
the kubernetes_manifest endpoint is not currently fulfilled by any charm on charmhub so these endpoints aren't required for the charm to run