### PR TITLE
chore: pin charm dependencies in tests (track/2.22)

### DIFF
--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -4,21 +4,21 @@ from charmed_kubeflow_chisme.testing import CharmSpec
 
 # for Istio in sidecar mode only:
 ISTIO_GATEWAY = CharmSpec(
-    charm="istio-gateway", channel="latest/edge", config={"kind": "ingress"}, trust=True
+    charm="istio-gateway", channel="1.28/edge", config={"kind": "ingress"}, trust=True
 )
 ISTIO_PILOT = CharmSpec(
     charm="istio-pilot",
-    channel="latest/edge",
+    channel="1.28/edge",
     config={"default-gateway": "test-gateway"},
     trust=True,
 )
 
 METACONTROLLER_OPERATOR = CharmSpec(
-    charm="metacontroller-operator", channel="latest/edge", trust=True
+    charm="metacontroller-operator", channel="4.11/edge", trust=True
 )
 MINIO = CharmSpec(
     charm="minio",
-    channel="latest/edge",
+    channel="1.10/edge",
     config={
         "access-key": "minio",
         "secret-key": "minio123",
@@ -29,7 +29,7 @@ MINIO = CharmSpec(
 MYSQL_K8S = CharmSpec(
     charm="mysql-k8s", channel="8.0/stable", config={"profile": "testing"}, trust=True
 )
-RESOURCE_DISPATCHER = CharmSpec(charm="resource-dispatcher", channel="latest/edge", trust=True)
+RESOURCE_DISPATCHER = CharmSpec(charm="resource-dispatcher", channel="2.0/edge", trust=True)
 KUBEFLOW_PROFILES = CharmSpec(
     charm="kubeflow-profiles",
     channel="latest/edge",


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External (resolved via Terraform Solutions track/1.11 — fallback, no Solutions branch references this charm-repo track)
- `istio-gateway`: `latest/edge` → `1.28/edge`
- `istio-pilot`: `latest/edge` → `1.28/edge`
- `metacontroller-operator`: `latest/edge` → `4.11/edge`
- `minio`: `latest/edge` → `1.10/edge`
- `resource-dispatcher`: `latest/edge` → `2.0/edge`

### Unresolved (left unchanged)
- `mysql-k8s` (`8.0/stable`) — mysql-k8s not pinned in Solutions track/1.11 (fallback)

Refs: canonical/bundle-kubeflow#1379
