### PR TITLE
fix: handle multiple `istio-ingress-route` relations 

### DIFF
--- a/concierge.yaml
+++ b/concierge.yaml
@@ -13,7 +13,7 @@ providers:
       load-balancer:
         enabled: true
         l2-mode: true
-        cidrs: 10.64.140.43/32
+        cidrs: 10.64.140.42/31  # NOTE: at least two IPs required for integration tests: one for each of the two Istio ingress gateways
     bootstrap-constraints:
       root-disk: 2G
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -5293,4 +5293,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "bd9936faf1ae03cea51c7d7cb02007ca714db02d4da8cde52009e26f409f69eb"
+content-hash = "a1de6289c904facfec234a3bc6a9b36b1377f6b84b44b6e786c5d114f952ff18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ lightkube = "^0.17.1"
 minio = "^7.2.15"
 pytest-operator = "^0.42.0"
 requests = "^2.32.4"
+tenacity = "^9.0.0"
 
 [project]
 name = "mlflow-operator"

--- a/src/charm.py
+++ b/src/charm.py
@@ -495,11 +495,15 @@ class MlflowCharm(CharmBase):
             raise ErrorWithStatus("Waiting for leadership", WaitingStatus)
 
     def _check_no_conflicting_ingress_relations(self) -> None:
-        """Check that ambient-mode and sidecar-mode ingress relations are not both set."""
-        ambient_relation = self.model.get_relation(INGRESS_MODES_TO_RELATION_NAMES["ambient"])
-        sidecar_relation = self.model.get_relation(INGRESS_MODES_TO_RELATION_NAMES["sidecar"])
+        """Check that ambient-mode and sidecar-mode ingress relations are not both set.
 
-        if ambient_relation and sidecar_relation:
+        Each endpoint may hold any number of relations, so this inspects the full list
+        of relations on each endpoint rather than assuming at most one.
+        """
+        ambient_relations = self.model.relations[INGRESS_MODES_TO_RELATION_NAMES["ambient"]]
+        sidecar_relations = self.model.relations[INGRESS_MODES_TO_RELATION_NAMES["sidecar"]]
+
+        if ambient_relations and sidecar_relations:
             self.logger.error(
                 f"Both '{INGRESS_MODES_TO_RELATION_NAMES["ambient"]}' and "
                 f"'{INGRESS_MODES_TO_RELATION_NAMES["sidecar"]}' relations are present."
@@ -660,6 +664,8 @@ class MlflowCharm(CharmBase):
 
     def _on_ambient_mode_ingress_ready(self, _):
         """Configure the ingess for ambient mode."""
+        # submit_config publishes this same config to every istio-ingress-route
+        # relation, so all related ingress providers are (re)configured at once.
         if self.unit.is_leader():
 
             try:

--- a/tests/integration/test_charm_ambient.py
+++ b/tests/integration/test_charm_ambient.py
@@ -18,6 +18,8 @@ import requests
 import yaml
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from charmed_kubeflow_chisme.testing import (
+    ISTIO_INGRESS_K8S_APP,
+    ISTIO_INGRESS_ROUTE_ENDPOINT,
     assert_alert_rules,
     assert_grafana_dashboards,
     assert_logging,
@@ -63,8 +65,25 @@ SECRET_SUFFIX = "-minio-artifact"
 TEST_EXPERIMENT_NAME = "test-experiment"
 PROFILE_FILE = "./tests/integration/profile.yaml"
 
+# A second istio-ingress-k8s instance used to verify multiple-ingress support.
+SECOND_INGRESS_APP = "istio-ingress-k8s-alt"
+INGRESS_CHANNEL = "2/stable"
+# Name of the HTTPRoute submitted by mlflow (see charm._ingress_config).
+INGRESS_ROUTE_NAME = "http-route"
+# Gateway listener section for cleartext HTTP on port 80.
+HTTP_SECTION_NAME = "http-80"
+# Path matched by the mlflow HTTPRoute.
+INGRESS_ROUTE_PATH = HTTP_PATH
+
 PodDefault = create_namespaced_resource("kubeflow.org", "v1alpha1", "PodDefault", "poddefaults")
 Profile = create_global_resource("kubeflow.org", "v1", "Profile", "profiles")
+# Gateway API generic resources, resolved at runtime via lightkube.
+HTTPROUTE_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "HTTPRoute", "httproutes"
+)
+GATEWAY_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "Gateway", "gateways"
+)
 
 
 def _safe_load_file_to_text(filename: str) -> str:
@@ -549,3 +568,89 @@ class TestCharm:
         for name in poddefaults_names:
             pod_default = lightkube_client.get(PodDefault, name, namespace=profile_namespace)
             assert pod_default is not None
+
+    @pytest.mark.abort_on_fail
+    async def test_deploy_and_relate_second_ingress(self, ops_test: OpsTest):
+        """Deploy a second istio-ingress-k8s and relate it to mlflow.
+
+        mlflow must accept more than one istio-ingress-route relation without
+        erroring, so it should remain active after the second ingress is related.
+        """
+        await ops_test.model.deploy(
+            ISTIO_INGRESS_K8S_APP,
+            application_name=SECOND_INGRESS_APP,
+            channel=INGRESS_CHANNEL,
+            trust=True,
+        )
+        await ops_test.model.wait_for_idle(
+            [SECOND_INGRESS_APP],
+            raise_on_blocked=False,
+            raise_on_error=False,
+            wait_for_active=True,
+            timeout=60 * 15,
+        )
+
+        await ops_test.model.integrate(
+            f"{SECOND_INGRESS_APP}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+            f"{CHARM_NAME}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+        )
+        await ops_test.model.wait_for_idle(
+            [CHARM_NAME, SECOND_INGRESS_APP],
+            status="active",
+            raise_on_blocked=False,
+            raise_on_error=False,
+            timeout=60 * 10,
+            idle_period=30,
+        )
+
+        assert ops_test.model.applications[CHARM_NAME].units[0].workload_status == "active"
+
+    @retry(stop=stop_after_delay(120), wait=wait_fixed(2), reraise=True)
+    @pytest.mark.abort_on_fail
+    async def test_httproute_attached_to_second_gateway(
+        self, ops_test: OpsTest, lightkube_client: lightkube.Client
+    ):
+        """Verify the HTTPRoute for the second ingress is created and bound to its Gateway.
+
+        The istio-ingress-k8s charm names each route
+        ``{source_app}-{route_name}-httproute-{section}-{ingress_app}`` and binds it to a
+        Gateway named after the ingress application via ``parentRefs``. We assert that the
+        route created for the second ingress is attached to the *second* Gateway (not the
+        first) and routes the mlflow path to the mlflow backend.
+        """
+        namespace = ops_test.model.name
+
+        expected_route_name = (
+            f"{CHARM_NAME}-{INGRESS_ROUTE_NAME}-httproute-{HTTP_SECTION_NAME}-{SECOND_INGRESS_APP}"
+        )
+
+        # The second Gateway should exist, named after the second ingress application.
+        lightkube_client.get(GATEWAY_RESOURCE, name=SECOND_INGRESS_APP, namespace=namespace)
+
+        httproute = lightkube_client.get(
+            HTTPROUTE_RESOURCE, name=expected_route_name, namespace=namespace
+        )
+
+        parent_refs = httproute.spec["parentRefs"]
+        assert len(parent_refs) == 1
+        # The route must be attached to the SECOND gateway, not the first.
+        assert parent_refs[0]["name"] == SECOND_INGRESS_APP
+        assert parent_refs[0]["sectionName"] == HTTP_SECTION_NAME
+
+        # And it must route the mlflow path to the mlflow backend.
+        rule = httproute.spec["rules"][0]
+        assert rule["matches"][0]["path"]["value"] == INGRESS_ROUTE_PATH
+        assert rule["backendRefs"][0]["name"] == CHARM_NAME
+
+    @retry(stop=stop_after_delay(600), wait=wait_fixed(10))
+    @pytest.mark.abort_on_fail
+    async def test_ui_is_accessible_after_second_ingress(
+        self, lightkube_client, ops_test: OpsTest
+    ):
+        """Verify the UI is still accessible through the ingress after the second ingress."""
+        await assert_path_reachable_through_ingress(
+            http_path=HTTP_PATH,
+            namespace=ops_test.model.name,
+            expected_content_type="text/html",
+            expected_response_text="MLflow",
+        )

--- a/tests/integration/test_charm_ambient.py
+++ b/tests/integration/test_charm_ambient.py
@@ -110,6 +110,16 @@ def deploy_k8s_resources(template_files: str):
     k8s_resource_handler.apply()
 
 
+async def assert_ui_is_accessible(ops_test: OpsTest):
+    """Verify that UI is accessible through the ingress gateway."""
+    await assert_path_reachable_through_ingress(
+        http_path=HTTP_PATH,
+        namespace=ops_test.model.name,
+        expected_content_type="text/html",
+        expected_response_text="MLflow",
+    )
+
+
 @pytest.fixture(scope="module")
 async def profile_namespace(ops_test: OpsTest, lightkube_client: lightkube.Client) -> str:
     """Ensure a kubeflow profile namespace exists for tests and clean it up afterwards."""
@@ -435,12 +445,7 @@ class TestCharm:
     @pytest.mark.abort_on_fail
     async def test_ui_is_accessible(self, lightkube_client, ops_test: OpsTest):
         """Verify that UI is accessible through the ingress gateway."""
-        await assert_path_reachable_through_ingress(
-            http_path=HTTP_PATH,
-            namespace=ops_test.model.name,
-            expected_content_type="text/html",
-            expected_response_text="MLflow",
-        )
+        await assert_ui_is_accessible(ops_test)
 
     @retry(
         stop=stop_after_delay(300),
@@ -648,9 +653,4 @@ class TestCharm:
         self, lightkube_client, ops_test: OpsTest
     ):
         """Verify the UI is still accessible through the ingress after the second ingress."""
-        await assert_path_reachable_through_ingress(
-            http_path=HTTP_PATH,
-            namespace=ops_test.model.name,
-            expected_content_type="text/html",
-            expected_response_text="MLflow",
-        )
+        await assert_ui_is_accessible(ops_test)

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -753,8 +753,26 @@ class TestCharm:
         "charm.KubernetesServicePatch",
         lambda x, y, service_name, service_type, refresh_event: None,
     )
-    def test_multiple_ambient_ingress_relations(self, harness: Harness):
-        """Test that multiple istio-ingress-route relations are handled without erroring."""
+    @patch(
+        "charm.MlflowCharm._validate_default_s3_bucket_name_and_access", lambda *args, **kw: True
+    )
+    @patch(
+        "charm.S3BucketWrapper.__init__",
+        lambda *args, **kw: None,
+    )
+    @patch("charm.MlflowCharm._get_object_storage_data", return_value=OBJECT_STORAGE_DATA)
+    @patch("charm.MlflowCharm._get_relational_db_data", return_value=RELATIONAL_DB_DATA)
+    @patch("charm.MlflowCharm._get_interfaces")
+    @patch("charm.ServiceMeshConsumer")
+    def test_multiple_ambient_ingress_relations(
+        self,
+        _: MagicMock,
+        __: MagicMock,
+        ___: MagicMock,
+        ____: MagicMock,
+        harness: Harness,
+    ):
+        """Test the charm reconciles to active with more than one istio-ingress-route relation."""
         harness.begin()
 
         # Add more than one relation on the ambient ingress endpoint
@@ -765,9 +783,16 @@ class TestCharm:
         )
         harness.add_relation_unit(second_relation_id, f"{second_app}/0")
 
-        # Inspecting the full list of relations per endpoint must not raise even
-        # though there is more than one relation on a single endpoint.
-        harness.charm._check_no_conflicting_ingress_relations()
+        # adding the relation is what triggers the charm to reconcile
+        harness.charm.on[RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE].relation_changed.emit(
+            harness.charm.framework.model.get_relation(
+                RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE, second_relation_id
+            )
+        )
+
+        # More than one relation on the istio-ingress-route endpoint must not block
+        # the charm; it should reconcile all the way to active.
+        assert isinstance(harness.charm.model.unit.status, ActiveStatus)
 
     @patch(
         "charm.KubernetesServicePatch",

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -749,6 +749,26 @@ class TestCharm:
         "charm.KubernetesServicePatch",
         lambda x, y, service_name, service_type, refresh_event: None,
     )
+    def test_multiple_ambient_ingress_relations(self, harness: Harness):
+        """Test that multiple istio-ingress-route relations are handled without erroring."""
+        harness.begin()
+
+        # Add more than one relation on the ambient ingress endpoint
+        add_relation(harness, relation_endpoint=RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE)
+        second_app = f"app-for-{RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE}-2"
+        second_relation_id = harness.add_relation(
+            RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE, second_app
+        )
+        harness.add_relation_unit(second_relation_id, f"{second_app}/0")
+
+        # Inspecting the full list of relations per endpoint must not raise even
+        # though there is more than one relation on a single endpoint.
+        harness.charm._check_no_conflicting_ingress_relations()
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
     @patch(
         "charm.MlflowCharm._validate_default_s3_bucket_name_and_access", lambda *args, **kw: True
     )

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 import yaml
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
-from charms.istio_ingress_k8s.v0.istio_ingress_route import ProtocolType
+from charms.istio_ingress_k8s.v0.istio_ingress_route import (
+    HTTPPathMatchType,
+    IstioIngressRouteConfig,
+    ProtocolType,
+)
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import ChangeError, Service
 from ops.testing import Harness
@@ -764,6 +768,64 @@ class TestCharm:
         # Inspecting the full list of relations per endpoint must not raise even
         # though there is more than one relation on a single endpoint.
         harness.charm._check_no_conflicting_ingress_relations()
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    @patch(
+        "charm.MlflowCharm._validate_default_s3_bucket_name_and_access", lambda *args, **kw: True
+    )
+    @patch(
+        "charm.S3BucketWrapper.__init__",
+        lambda *args, **kw: None,
+    )
+    @patch("charm.MlflowCharm._get_object_storage_data", return_value=OBJECT_STORAGE_DATA)
+    @patch("charm.MlflowCharm._get_relational_db_data", return_value=RELATIONAL_DB_DATA)
+    @patch("charm.MlflowCharm._get_interfaces")
+    @patch("charm.ServiceMeshConsumer")
+    def test_each_istio_ingress_route_relation_receives_config(
+        self,
+        _: MagicMock,
+        __: MagicMock,
+        ___: MagicMock,
+        ____: MagicMock,
+        harness: Harness,
+    ):
+        """Test that every istio-ingress-route relation databag receives a valid config."""
+        harness.begin()
+
+        # add more than one relation on the ambient ingress endpoint
+        first_relation_id, _ = add_relation(
+            harness, relation_endpoint=RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE
+        )
+        second_app = f"app-for-{RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE}-2"
+        second_relation_id = harness.add_relation(
+            RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE, second_app
+        )
+        harness.add_relation_unit(second_relation_id, f"{second_app}/0")
+
+        # trigger the ingress-ready event so the real requirer publishes the same
+        # config to every istio-ingress-route relation databag
+        harness.charm.ambient_mode_ingress.on.ready.emit(
+            harness.charm.framework.model.get_relation(
+                RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE, first_relation_id
+            )
+        )
+
+        # assert each relation databag holds a valid HTTPRoute config
+        for relation_id in (first_relation_id, second_relation_id):
+            app_data = harness.get_relation_data(relation_id, harness.charm.app.name)
+            assert "config" in app_data
+            config = IstioIngressRouteConfig.model_validate_json(app_data["config"])
+
+            assert len(config.http_routes) == 1
+            http_route = config.http_routes[0]
+            assert http_route.matches[0].path.type == HTTPPathMatchType.PathPrefix
+            assert http_route.matches[0].path.value == EXPECTED_INGRESS_PATH_MATCHED_PREFIX
+            assert http_route.backends[0].service == DEFAULT_JUJU_APP_NAME
+            assert http_route.backends[0].port == EXPECTED_K8S_SERVICE_HTTP_PORT
+            assert config.listeners[0].name == "http-80"
 
     @patch(
         "charm.KubernetesServicePatch",


### PR DESCRIPTION
Part of https://github.com/canonical/bundle-kubeflow/issues/1446

Use `model.relations[...]` instead of `model.get_relation(...)` when checking ingress relations, so the charm no longer raises `TooManyRelatedAppsError` when more than one `istio-ingress-route` relation is present.

Add unit tests covering multiple `istio-ingress-route` relations and verifying each relation receives a valid `HTTPRoute` config.

_Note: this PR was created with the help of AI_