### PR TITLE
refactor: remove ambiguity from charm logic

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -298,7 +298,7 @@ class MlflowCharm(CharmBase):
 
     def _get_mlflow_serve_env_vars(self, relational_db_data, bucket_name):
         """Return environment variables for the `mflow serve` command.
-        
+
         See here how such environment variables provide defaults for `mlflow serve` CLI options:
         https://mlflow.org/docs/2.22.1/api_reference/cli.html#mlflow-server
         """

--- a/src/charm.py
+++ b/src/charm.py
@@ -296,21 +296,21 @@ class MlflowCharm(CharmBase):
             refresh_event=self.on.config_changed,
         )
 
-    def _get_env_vars(self, relational_db_data, object_storage_data):
-        """Return environment variables based on model configuration."""
-
-        ret_env_vars = {
-            "MLFLOW_S3_ENDPOINT_URL": f"http://{object_storage_data['service']}.{object_storage_data['namespace']}:{object_storage_data['port']}",  # noqa: E501
-            "AWS_ENDPOINT_URL": f"http://{object_storage_data['service']}.{object_storage_data['namespace']}:{object_storage_data['port']}",  # noqa: E501
-            "AWS_ACCESS_KEY_ID": object_storage_data["access-key"],
-            "AWS_SECRET_ACCESS_KEY": object_storage_data["secret-key"],
-            "USE_SSL": str(object_storage_data["secure"]).lower(),
-            "DB_ROOT_PASSWORD": relational_db_data["password"],
-            "MLFLOW_TRACKING_URI": f"mysql+pymysql://{relational_db_data['username']}:{relational_db_data['password']}@{relational_db_data['host']}:{relational_db_data['port']}/{self._database_name}",  # noqa: E501
+    def _get_mlflow_serve_env_vars(self, relational_db_data, bucket_name):
+        """Return environment variables for the `mflow serve` command.
+        
+        See here how such environment variables provide defaults for `mlflow serve` CLI options:
+        https://mlflow.org/docs/2.22.1/api_reference/cli.html#mlflow-server
+        """
+        return {
+            "MLFLOW_BACKEND_STORE_URI": f"mysql+pymysql://{relational_db_data['username']}:{relational_db_data['password']}@{relational_db_data['host']}:{relational_db_data['port']}/{self._database_name}",  # noqa: E501
+            "MLFLOW_DEFAULT_ARTIFACT_ROOT": f"s3://{bucket_name}",
+            "MLFLOW_EXPOSE_PROMETHEUS": METRICS_PATH,
+            "MLFLOW_HOST": "0.0.0.0",
+            "MLFLOW_PORT": self._mlflow_port,
         }
-        return ret_env_vars
 
-    def _charmed_mlflow_layer(self, env_vars, default_artifact_root) -> Layer:
+    def _charmed_mlflow_layer(self, env_vars) -> Layer:
         """Create and return Pebble framework layer."""
 
         layer_config = {
@@ -320,22 +320,9 @@ class MlflowCharm(CharmBase):
                 self._container_name: {
                     "override": "replace",
                     "summary": "Entrypoint of mlflow-server image",
-                    "command": (
-                        "mlflow "
-                        "server "
-                        "--host "
-                        "0.0.0.0 "
-                        "--port "
-                        f"{self._mlflow_port} "
-                        "--backend-store-uri "
-                        f"{env_vars['MLFLOW_TRACKING_URI']} "
-                        "--default-artifact-root "
-                        f"s3://{default_artifact_root}/ "
-                        "--expose-prometheus "
-                        f"{METRICS_PATH}"
-                    ),
+                    "command": "mlflow server",
                     "startup": "enabled",
-                    "environment": env_vars,
+                    "environment": env_vars,  # defaults for `mlflow server` CLI option passed here
                 }
             },
         }
@@ -595,7 +582,6 @@ class MlflowCharm(CharmBase):
             interfaces = self._get_interfaces()
             object_storage_data = self._get_object_storage_data(interfaces)
             relational_db_data = self._get_relational_db_data()
-            envs = self._get_env_vars(relational_db_data, object_storage_data)
 
             self._check_no_conflicting_ingress_relations()
 
@@ -611,13 +597,15 @@ class MlflowCharm(CharmBase):
             ):
                 self._create_default_s3_bucket(s3_wrapper, bucket_name)
 
+            mlflow_serve_envs = self._get_mlflow_serve_env_vars(relational_db_data, bucket_name)
+
             if not self.container.can_connect():
                 raise ErrorWithStatus(
                     f"Container {self._container_name} is not ready", WaitingStatus
                 )
             self._reconcile_policy_resource_manager()
             self._update_layer(
-                self.container, self._container_name, self._charmed_mlflow_layer(envs, bucket_name)
+                self.container, self._container_name, self._charmed_mlflow_layer(mlflow_serve_envs)
             )
             if not self.exporter_container.can_connect():
                 raise ErrorWithStatus(

--- a/src/charm.py
+++ b/src/charm.py
@@ -297,9 +297,9 @@ class MlflowCharm(CharmBase):
         )
 
     def _get_mlflow_serve_env_vars(self, relational_db_data, bucket_name):
-        """Return environment variables for the `mflow serve` command.
+        """Return environment variables for the `mlflow server` command.
 
-        See here how such environment variables provide defaults for `mlflow serve` CLI options:
+        See here how such environment variables provide defaults for `mlflow server` CLI options:
         https://mlflow.org/docs/2.22.1/api_reference/cli.html#mlflow-server
         """
         return {

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -48,7 +48,7 @@ EXPECTED_ENVIRONMENT = {
     "MLFLOW_DEFAULT_ARTIFACT_ROOT": f"s3://{BUCKET_NAME}",
     "MLFLOW_EXPOSE_PROMETHEUS": "/metrics",
     "MLFLOW_HOST": "0.0.0.0",
-    "MLFLOW_PORT": "5000",
+    "MLFLOW_PORT": 5000,
 }
 EXPECTED_SERVICE = {
     "mlflow-server": Service(

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -19,7 +19,6 @@ from serialized_data_interface import NoCompatibleVersions, NoVersionsListed
 
 from charm import MeshType, MlflowCharm
 
-
 BUCKET_NAME = "mlflow"
 CHARM_NAME = "mlflow-server"
 DEFAULT_JUJU_APP_NAME = CHARM_NAME
@@ -436,7 +435,7 @@ class TestCharm:
         harness.charm._update_layer(
             harness.charm.container,
             harness.charm._container_name,
-            harness.charm._charmed_mlflow_layer({"MLFLOW_TRACKING_URI": "test"}, ""),
+            harness.charm._charmed_mlflow_layer(EXPECTED_ENVIRONMENT),
         )
         assert harness.charm.container.get_plan().services == EXPECTED_SERVICE
 
@@ -444,12 +443,12 @@ class TestCharm:
         "charm.KubernetesServicePatch",
         lambda x, y, service_name, service_type, refresh_event: None,
     )
-    def test_get_env_vars(
+    def test_get_mlflow_serve_env_vars(
         self,
         harness: Harness,
     ):
         harness.begin()
-        envs = harness.charm._get_env_vars(RELATIONAL_DB_DATA, BUCKET_NAME)
+        envs = harness.charm._get_mlflow_serve_env_vars(RELATIONAL_DB_DATA, BUCKET_NAME)
         assert envs == EXPECTED_ENVIRONMENT
 
     @patch(

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -19,18 +19,7 @@ from serialized_data_interface import NoCompatibleVersions, NoVersionsListed
 
 from charm import MeshType, MlflowCharm
 
-EXPECTED_SERVICE = {
-    "mlflow-server": Service(
-        "mlflow-server",
-        raw={
-            "summary": "Entrypoint of mlflow-server image",
-            "startup": "enabled",
-            "override": "replace",
-            "command": "mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri test --default-artifact-root s3:/// --expose-prometheus /metrics",  # noqa: E501
-            "environment": {"MLFLOW_TRACKING_URI": "test"},
-        },
-    )
-}
+
 BUCKET_NAME = "mlflow"
 CHARM_NAME = "mlflow-server"
 DEFAULT_JUJU_APP_NAME = CHARM_NAME
@@ -53,18 +42,27 @@ RELATIONAL_DB_DATA = {
     "port": "port",
 }
 
-EXPECTED_ENVIRONMENT = {
-    "AWS_ACCESS_KEY_ID": "minio-access-key",
-    "AWS_ENDPOINT_URL": "http://service.namespace:1234",
-    "AWS_SECRET_ACCESS_KEY": "minio-super-secret-key",
-    "DB_ROOT_PASSWORD": "lorem-ipsum",
-    "MLFLOW_S3_ENDPOINT_URL": "http://service.namespace:1234",
-    "MLFLOW_TRACKING_URI": "mysql+pymysql://username:lorem-ipsum@host:port/mlflow",
-    "USE_SSL": "true",
-}
-
 SECRETS_TEST_FILES = ["tests/test_data/secret.yaml.j2"]
 
+EXPECTED_ENVIRONMENT = {
+    "MLFLOW_BACKEND_STORE_URI": "mysql+pymysql://username:lorem-ipsum@host:port/mlflow",
+    "MLFLOW_DEFAULT_ARTIFACT_ROOT": f"s3://{BUCKET_NAME}",
+    "MLFLOW_EXPOSE_PROMETHEUS": "/metrics",
+    "MLFLOW_HOST": "0.0.0.0",
+    "MLFLOW_PORT": "5000",
+}
+EXPECTED_SERVICE = {
+    "mlflow-server": Service(
+        "mlflow-server",
+        raw={
+            "summary": "Entrypoint of mlflow-server image",
+            "startup": "enabled",
+            "override": "replace",
+            "command": "mlflow server",
+            "environment": EXPECTED_ENVIRONMENT,
+        },
+    )
+}
 EXPECTED_INGRESS_PATH_MATCHED_PREFIX = "/mlflow/"
 EXPECTED_INGRESS_PATH_REWRITTEN_PREFIX = "/"
 EXPECTED_K8S_SERVICE_HTTP_PORT = 5000
@@ -451,7 +449,7 @@ class TestCharm:
         harness: Harness,
     ):
         harness.begin()
-        envs = harness.charm._get_env_vars(RELATIONAL_DB_DATA, OBJECT_STORAGE_DATA)
+        envs = harness.charm._get_env_vars(RELATIONAL_DB_DATA, BUCKET_NAME)
         assert envs == EXPECTED_ENVIRONMENT
 
     @patch(


### PR DESCRIPTION
This pull request refactors the charm to that any ambiguity is removed without changing functionality at all.

Many environment variables were set but not used, and many other ones could be set in a unified place to avoid having both environment variables and CLI options for the workload's entrypoint.

See [here](https://mlflow.org/docs/2.22.1/api_reference/cli.html#mlflow-server) how and which environment variables are employed as defaults for `mlflow server` CLI options, the only entrypoint of the workload's rock.