### PR TITLE
fix: Grant contents: read to ci-tests job in release workflow (#423)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ jobs:
   ci-tests:
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
+    permissions:
+      actions: read
+      contents: read
 
   release:
     strategy:


### PR DESCRIPTION
Manual backport of https://github.com/canonical/mlflow-operator/pull/423 created because we forgot to add the backport label before merging