### PR TITLE
feat: parametrize proxy mode

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,3 +31,11 @@ options:
     description: Deploy the NodePort service for MLFlow
     type: boolean
     default: true
+  serve_artifacts:
+    description: |
+      Whether to let the tracking server act as a proxy to interact with the artifact store on behalf of the client.
+
+      Analogous to:
+      https://mlflow.org/docs/latest/api_reference/cli.html#cmdoption-mlflow-server-serve-artifacts
+    type: boolean
+    default: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -396,9 +396,7 @@ class MlflowCharm(CharmBase):
             # Base64-encoded S3 CA bundle so clients doing direct (non-proxy) object storage
             # I/O can mount it and trust the store's TLS certificate. Empty when there is none.
             "s3_ca_bundle_b64": (
-                base64.b64encode("\n".join(tls_ca_chain).encode()).decode()
-                if tls_ca_chain
-                else ""
+                base64.b64encode("\n".join(tls_ca_chain).encode()).decode() if tls_ca_chain else ""
             ),
         }
         return secrets_context

--- a/src/charm.py
+++ b/src/charm.py
@@ -763,23 +763,30 @@ class MlflowCharm(CharmBase):
             self.logger.error("Failed to generate container configuration.")
             raise error
 
+        s3_bucket_uri = f"s3://{self._resolve_bucket_name(artifact_store_data)}"
+
         environment_variables = {
             "MLFLOW_BACKEND_STORE_URI": f"mysql+pymysql://{relational_db_data['username']}:{relational_db_data['password']}@{relational_db_data['host']}:{relational_db_data['port']}/{self._database_name}",  # noqa: E501
-            "MLFLOW_DEFAULT_ARTIFACT_ROOT": f"s3://{self._resolve_bucket_name(artifact_store_data)}",
             "MLFLOW_EXPOSE_PROMETHEUS": METRICS_PATH,
             "MLFLOW_HOST": "0.0.0.0",
             "MLFLOW_PORT": self._mlflow_port,
-            "MLFLOW_SERVE_ARTIFACTS": "False",
         }
-
         if self.proxy_mode:
             environment_variables.update(
                 {
                     "AWS_ACCESS_KEY_ID": artifact_store_data["access_key"],
                     "AWS_SECRET_ACCESS_KEY": artifact_store_data["secret_key"],
+                    "MLFLOW_ARTIFACTS_DESTINATION": s3_bucket_uri,
+                    "MLFLOW_DEFAULT_ARTIFACT_ROOT": "mlflow-artifacts:/",
                     "MLFLOW_S3_ENDPOINT_URL": self._extract_s3_endpoint(artifact_store_data),
-                    # TODO: how about artifact destination?
                     "MLFLOW_SERVE_ARTIFACTS": "True",
+                }
+            )
+        else:
+            environment_variables.update(
+                {
+                    "MLFLOW_DEFAULT_ARTIFACT_ROOT": s3_bucket_uri,
+                    "MLFLOW_SERVE_ARTIFACTS": "False",
                 }
             )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -80,8 +80,9 @@ SECRETS_FILES = [
     "src/secrets/mlflow-minio-artifact.j2",
 ]
 SERVICE_MESH_RELATION_NAME = "service-mesh"
-# Path inside the workload container where the artifact store's TLS CA bundle is written, so the
-# NOTE: under the Pebble user's home directory, writable by the non-root user:
+# path inside the workload container where the artifact store's TLS CA bundle is written to be then
+# referenced by the AWS_CA_BUNDLE environment variable, so that the tracking server can trust the
+# store's TLS certificate - NOTE: under Pebble's home directory, writable by the non-root user:
 S3_CA_BUNDLE_CONTAINER_PATH = "/var/lib/pebble/default/s3-ca-bundle.pem"
 
 
@@ -393,8 +394,8 @@ class MlflowCharm(CharmBase):
             "access_key": artifact_store_data["access_key"],
             "secret_access_key": artifact_store_data["secret_key"],
             "is_proxy_mode_enabled": self.proxy_mode,
-            # Base64-encoded S3 CA bundle so clients doing direct (non-proxy) object storage
-            # I/O can mount it and trust the store's TLS certificate. Empty when there is none.
+            # base64-encoded S3 CA bundle for clients to directly trust the artifact store when in
+            # no proxy mode and when private TLS certificates are used:
             "s3_ca_bundle_b64": (
                 base64.b64encode("\n".join(tls_ca_chain).encode()).decode() if tls_ca_chain else ""
             ),
@@ -417,8 +418,8 @@ class MlflowCharm(CharmBase):
                 f"{self._mlflow_port}"
             ),
             "is_proxy_mode_enabled": self.proxy_mode,
-            # Whether to mount the S3 CA bundle into client pods and point AWS_CA_BUNDLE at it,
-            # so their direct (non-proxy) boto3 connections trust the store's TLS certificate.
+            # whether to mount the S3 CA bundle into client pods and point AWS_CA_BUNDLE at it, so
+            # their direct (no-proxy mode) connections trust the artifact store's TLS certificate:
             "s3_ca_bundle_present": bool(artifact_store_data["tls_ca_chain"]),
         }
         return poddefaults_context
@@ -736,10 +737,13 @@ class MlflowCharm(CharmBase):
     def _reconcile_s3_ca_bundle(self, artifact_store_data: ArtifactStoreData) -> None:
         """Push the artifact store's TLS CA bundle into the workload container when required.
 
-        In proxy mode the tracking server proxies artifact writes to the S3 store itself, so it
-        must trust the store's TLS CA. The bundle is written to the path referenced by the
-        AWS_CA_BUNDLE environment variable set in `_generate_environment`. Non-proxy mode and
-        stores without a CA chain need no bundle.
+        In proxy mode the tracking server directly accesses the S3 store, so it must trust the
+        store's TLS CA. The bundle is written to the path referenced by the AWS_CA_BUNDLE
+        environment variable set in `_generate_environment`, a variable that the boto3 client that
+        the tracking server relies on behind the scenes.
+
+        When the tracking server is not in proxy mode or when the artifact store does not have a
+        private CA chain, this is not necessary.
         """
         tls_ca_chain = artifact_store_data["tls_ca_chain"]
         if self.proxy_mode and tls_ca_chain:

--- a/src/charm.py
+++ b/src/charm.py
@@ -80,8 +80,8 @@ SECRETS_FILES = [
 ]
 SERVICE_MESH_RELATION_NAME = "service-mesh"
 # Path inside the workload container where the artifact store's TLS CA bundle is written, so the
-# tracking server can trust the store while proxying artifact writes in proxy mode.
-S3_CA_BUNDLE_CONTAINER_PATH = "/etc/mlflow/s3-ca-bundle.pem"
+# NOTE: under the Pebble user's home directory, writable by the non-root user:
+S3_CA_BUNDLE_CONTAINER_PATH = "/var/lib/pebble/default/s3-ca-bundle.pem"
 
 
 # Normalized artifact store data returned by MlflowCharm._get_artifact_store_data, covering

--- a/src/charm.py
+++ b/src/charm.py
@@ -731,10 +731,6 @@ class MlflowCharm(CharmBase):
         AWS_CA_BUNDLE environment variable set in `_generate_environment`. Non-proxy mode and
         stores without a CA chain need no bundle.
         """
-        if not self.container.can_connect():
-            raise ErrorWithStatus(
-                f"Container {self._container_name} is not ready", WaitingStatus
-            )
         tls_ca_chain = artifact_store_data["tls_ca_chain"]
         if self.proxy_mode and tls_ca_chain:
             self.container.push(
@@ -801,9 +797,6 @@ class MlflowCharm(CharmBase):
                 "MLFLOW_S3_ENDPOINT_URL": self._extract_s3_endpoint(artifact_store_data),
                 "MLFLOW_SERVE_ARTIFACTS": "True",
             }
-            # In proxy mode the server writes artifacts to the S3 store itself. For a TLS store
-            # with a custom CA, boto3 trusts it via the CA bundle that _reconcile_s3_ca_bundle
-            # pushes into the container, referenced here through AWS_CA_BUNDLE.
             if artifact_store_data["tls_ca_chain"]:
                 proxy_environment_variables["AWS_CA_BUNDLE"] = S3_CA_BUNDLE_CONTAINER_PATH
             environment_variables.update(proxy_environment_variables)
@@ -889,8 +882,6 @@ class MlflowCharm(CharmBase):
 
             self._ensure_bucket_exists()
 
-            self._reconcile_s3_ca_bundle(self._get_artifact_store_data(interfaces))
-
             update_layer(
                 self._container_name, self._container, self._mlflow_server_layer, self.logger
             )
@@ -899,6 +890,9 @@ class MlflowCharm(CharmBase):
                 raise ErrorWithStatus(
                     f"Container {self._container_name} is not ready", WaitingStatus
                 )
+
+            self._reconcile_s3_ca_bundle(self._get_artifact_store_data(interfaces))
+
             self._reconcile_policy_resource_manager()
 
             if not self.exporter_container.can_connect():

--- a/src/charm.py
+++ b/src/charm.py
@@ -401,7 +401,7 @@ class MlflowCharm(CharmBase):
             raise error
         poddefaults_context = {
             "app_name": self.app.name,
-            "s3_endpoint": self.extract_s3_endpoint(artifact_store_data),
+            "s3_endpoint": self._extract_s3_endpoint(artifact_store_data),
             "mlflow_endpoint": (
                 f"http://{self.app.name}.{self._namespace}.svc.cluster.local:"
                 f"{self._mlflow_port}"

--- a/src/charm.py
+++ b/src/charm.py
@@ -379,14 +379,15 @@ class MlflowCharm(CharmBase):
     def secrets_context(self) -> dict:
         try:
             interfaces = self._get_interfaces()
-            object_storage = self._get_artifact_store_data(interfaces)
+            artifact_store_data = self._get_artifact_store_data(interfaces)
         except ErrorWithStatus as error:
             self.logger.error("Failed to generate container configuration.")
             raise error
         secrets_context = {
             "app_name": self.app.name,
-            "access_key": object_storage["access_key"],
-            "secret_access_key": object_storage["secret_key"],
+            "access_key": artifact_store_data["access_key"],
+            "secret_access_key": artifact_store_data["secret_key"],
+            "is_proxy_mode_enabled": self.proxy_mode,
         }
         return secrets_context
 
@@ -394,21 +395,25 @@ class MlflowCharm(CharmBase):
     def poddefaults_context(self) -> dict:
         try:
             interfaces = self._get_interfaces()
-            object_storage = self._get_artifact_store_data(interfaces)
+            artifact_store_data = self._get_artifact_store_data(interfaces)
         except ErrorWithStatus as error:
             self.logger.error("Failed to generate container configuration.")
             raise error
-        scheme = "https" if object_storage["secure"] else "http"
-        s3_endpoint = f"{scheme}://{object_storage['host']}:{object_storage['port']}"
         poddefaults_context = {
             "app_name": self.app.name,
-            "s3_endpoint": s3_endpoint,
+            "s3_endpoint": self.extract_s3_endpoint(artifact_store_data),
             "mlflow_endpoint": (
                 f"http://{self.app.name}.{self._namespace}.svc.cluster.local:"
                 f"{self._mlflow_port}"
             ),
+            "is_proxy_mode_enabled": self.proxy_mode,
         }
         return poddefaults_context
+
+    @property
+    def proxy_mode(self) -> bool:
+        """Return whether the tracking server acts as a proxy to the artifact store."""
+        return self.model.config["serve_artifacts"]
 
     def _get_interfaces(self):
         """Retrieve interface object."""
@@ -606,6 +611,12 @@ class MlflowCharm(CharmBase):
         )
 
     @staticmethod
+    def _extract_s3_endpoint(artifact_store_data: ArtifactStoreData) -> str:
+        """Extract the s3 endpoint URL from the artifact store data."""
+        scheme = "https" if artifact_store_data["secure"] else "http"
+        return f"{scheme}://{artifact_store_data['host']}:{artifact_store_data['port']}"
+
+    @staticmethod
     def _parse_s3_endpoint(endpoint: str) -> tuple:
         """Parse an s3 endpoint into a (host, port, secure) tuple.
 
@@ -630,11 +641,11 @@ class MlflowCharm(CharmBase):
     def _on_get_minio_credentials(self, event: ActionEvent):
         """Returns the credentials for minio as an action response."""
         try:
-            object_storage_data = self._get_artifact_store_data()
+            artifact_store_data = self._get_artifact_store_data()
             event.set_results(
                 {
-                    "access-key": object_storage_data["access_key"],
-                    "secret-access-key": object_storage_data["secret_key"],
+                    "access-key": artifact_store_data["access_key"],
+                    "secret-access-key": artifact_store_data["secret_key"],
                 }
             )
         except ErrorWithStatus:
@@ -671,19 +682,19 @@ class MlflowCharm(CharmBase):
 
     def _ensure_bucket_exists(self) -> None:
         """Ensure bucket on object storage exists by using a boto3 client."""
-        obj = self._get_artifact_store_data()
+        artifact_store_data = self._get_artifact_store_data()
 
         s3_wrapper = S3BucketWrapper(
-            access_key=obj.get("access_key"),
-            secret_access_key=obj.get("secret_key"),
-            s3_service=obj["host"],
-            s3_port=obj["port"],
-            secure=obj["secure"],
-            region=obj["region"],
-            tls_ca_chain=obj.get("tls_ca_chain"),
+            access_key=artifact_store_data.get("access_key"),
+            secret_access_key=artifact_store_data.get("secret_key"),
+            s3_service=artifact_store_data["host"],
+            s3_port=artifact_store_data["port"],
+            secure=artifact_store_data["secure"],
+            region=artifact_store_data["region"],
+            tls_ca_chain=artifact_store_data.get("tls_ca_chain"),
         )
 
-        bucket_name = self._resolve_bucket_name(obj)
+        bucket_name = self._resolve_bucket_name(artifact_store_data)
         try:
             self.unit.status = MaintenanceStatus(f"Checking if bucket {bucket_name} exists.")
             # Check if bucket already exists
@@ -746,20 +757,33 @@ class MlflowCharm(CharmBase):
         """
         try:
             interfaces = self._get_interfaces()
-            object_storage = self._get_artifact_store_data(interfaces)
+            artifact_store_data = self._get_artifact_store_data(interfaces)
             relational_db_data = self._get_relational_db_data()
         except ErrorWithStatus as error:
             self.logger.error("Failed to generate container configuration.")
             raise error
 
-        return {
+        environment_variables = {
             "MLFLOW_BACKEND_STORE_URI": f"mysql+pymysql://{relational_db_data['username']}:{relational_db_data['password']}@{relational_db_data['host']}:{relational_db_data['port']}/{self._database_name}",  # noqa: E501
-            "MLFLOW_DEFAULT_ARTIFACT_ROOT": f"s3://{self._resolve_bucket_name(object_storage)}",
+            "MLFLOW_DEFAULT_ARTIFACT_ROOT": f"s3://{self._resolve_bucket_name(artifact_store_data)}",
             "MLFLOW_EXPOSE_PROMETHEUS": METRICS_PATH,
             "MLFLOW_HOST": "0.0.0.0",
             "MLFLOW_PORT": self._mlflow_port,
             "MLFLOW_SERVE_ARTIFACTS": "False",
         }
+
+        if self.proxy_mode:
+            environment_variables.update(
+                {
+                    "AWS_ACCESS_KEY_ID": artifact_store_data["access_key"],
+                    "AWS_SECRET_ACCESS_KEY": artifact_store_data["secret_key"],
+                    "MLFLOW_S3_ENDPOINT_URL": self._extract_s3_endpoint(artifact_store_data),
+                    # TODO: how about artifact destination?
+                    "MLFLOW_SERVE_ARTIFACTS": "True",
+                }
+            )
+
+        return environment_variables
 
     def _reconcile_policy_resource_manager(self):
         if not self.unit.is_leader():
@@ -803,6 +827,10 @@ class MlflowCharm(CharmBase):
             template = Template(Path(file).read_text())
             rendered_template = template.render(**context)
             manifest = KubernetesManifest(rendered_template)
+            # skipping templates that render to an empty document, such as parametrized resources
+            # that are intentionally omitted when in proxy mode, so they are not sent as null:
+            if manifest.manifest is None:
+                continue
             manifests.append(manifest)
         return manifests
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -79,6 +79,9 @@ SECRETS_FILES = [
     "src/secrets/mlflow-minio-artifact.j2",
 ]
 SERVICE_MESH_RELATION_NAME = "service-mesh"
+# Path inside the workload container where the artifact store's TLS CA bundle is written, so the
+# tracking server can trust the store while proxying artifact writes in proxy mode.
+S3_CA_BUNDLE_CONTAINER_PATH = "/etc/mlflow/s3-ca-bundle.pem"
 
 
 # Normalized artifact store data returned by MlflowCharm._get_artifact_store_data, covering
@@ -720,6 +723,24 @@ class MlflowCharm(CharmBase):
             self.logger.warning(f"{msg}: {e}")
             raise ErrorWithStatus(msg, WaitingStatus)
 
+    def _reconcile_s3_ca_bundle(self, artifact_store_data: ArtifactStoreData) -> None:
+        """Push the artifact store's TLS CA bundle into the workload container when required.
+
+        In proxy mode the tracking server proxies artifact writes to the S3 store itself, so it
+        must trust the store's TLS CA. The bundle is written to the path referenced by the
+        AWS_CA_BUNDLE environment variable set in `_generate_environment`. Non-proxy mode and
+        stores without a CA chain need no bundle.
+        """
+        if not self.container.can_connect():
+            raise ErrorWithStatus(
+                f"Container {self._container_name} is not ready", WaitingStatus
+            )
+        tls_ca_chain = artifact_store_data["tls_ca_chain"]
+        if self.proxy_mode and tls_ca_chain:
+            self.container.push(
+                S3_CA_BUNDLE_CONTAINER_PATH, "\n".join(tls_ca_chain), make_dirs=True
+            )
+
     def _check_leader(self):
         """Check if this unit is a leader."""
         if not self.unit.is_leader():
@@ -772,16 +793,20 @@ class MlflowCharm(CharmBase):
             "MLFLOW_PORT": self._mlflow_port,
         }
         if self.proxy_mode:
-            environment_variables.update(
-                {
-                    "AWS_ACCESS_KEY_ID": artifact_store_data["access_key"],
-                    "AWS_SECRET_ACCESS_KEY": artifact_store_data["secret_key"],
-                    "MLFLOW_ARTIFACTS_DESTINATION": s3_bucket_uri,
-                    "MLFLOW_DEFAULT_ARTIFACT_ROOT": "mlflow-artifacts:/",
-                    "MLFLOW_S3_ENDPOINT_URL": self._extract_s3_endpoint(artifact_store_data),
-                    "MLFLOW_SERVE_ARTIFACTS": "True",
-                }
-            )
+            proxy_environment_variables = {
+                "AWS_ACCESS_KEY_ID": artifact_store_data["access_key"],
+                "AWS_SECRET_ACCESS_KEY": artifact_store_data["secret_key"],
+                "MLFLOW_ARTIFACTS_DESTINATION": s3_bucket_uri,
+                "MLFLOW_DEFAULT_ARTIFACT_ROOT": "mlflow-artifacts:/",
+                "MLFLOW_S3_ENDPOINT_URL": self._extract_s3_endpoint(artifact_store_data),
+                "MLFLOW_SERVE_ARTIFACTS": "True",
+            }
+            # In proxy mode the server writes artifacts to the S3 store itself. For a TLS store
+            # with a custom CA, boto3 trusts it via the CA bundle that _reconcile_s3_ca_bundle
+            # pushes into the container, referenced here through AWS_CA_BUNDLE.
+            if artifact_store_data["tls_ca_chain"]:
+                proxy_environment_variables["AWS_CA_BUNDLE"] = S3_CA_BUNDLE_CONTAINER_PATH
+            environment_variables.update(proxy_environment_variables)
         else:
             environment_variables.update(
                 {
@@ -863,6 +888,8 @@ class MlflowCharm(CharmBase):
             self._check_no_conflicting_ingress_relations()
 
             self._ensure_bucket_exists()
+
+            self._reconcile_s3_ca_bundle(self._get_artifact_store_data(interfaces))
 
             update_layer(
                 self._container_name, self._container, self._mlflow_server_layer, self.logger

--- a/src/charm.py
+++ b/src/charm.py
@@ -799,6 +799,8 @@ class MlflowCharm(CharmBase):
             }
             if artifact_store_data["tls_ca_chain"]:
                 proxy_environment_variables["AWS_CA_BUNDLE"] = S3_CA_BUNDLE_CONTAINER_PATH
+            if artifact_store_data["region"]:
+                proxy_environment_variables["AWS_DEFAULT_REGION"] = artifact_store_data["region"]
             environment_variables.update(proxy_environment_variables)
         else:
             environment_variables.update(

--- a/src/charm.py
+++ b/src/charm.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 #
 
+import base64
 import logging
 from pathlib import Path
 from typing import List, Optional, TypedDict
@@ -386,11 +387,19 @@ class MlflowCharm(CharmBase):
         except ErrorWithStatus as error:
             self.logger.error("Failed to generate container configuration.")
             raise error
+        tls_ca_chain = artifact_store_data["tls_ca_chain"]
         secrets_context = {
             "app_name": self.app.name,
             "access_key": artifact_store_data["access_key"],
             "secret_access_key": artifact_store_data["secret_key"],
             "is_proxy_mode_enabled": self.proxy_mode,
+            # Base64-encoded S3 CA bundle so clients doing direct (non-proxy) object storage
+            # I/O can mount it and trust the store's TLS certificate. Empty when there is none.
+            "s3_ca_bundle_b64": (
+                base64.b64encode("\n".join(tls_ca_chain).encode()).decode()
+                if tls_ca_chain
+                else ""
+            ),
         }
         return secrets_context
 
@@ -410,6 +419,9 @@ class MlflowCharm(CharmBase):
                 f"{self._mlflow_port}"
             ),
             "is_proxy_mode_enabled": self.proxy_mode,
+            # Whether to mount the S3 CA bundle into client pods and point AWS_CA_BUNDLE at it,
+            # so their direct (non-proxy) boto3 connections trust the store's TLS certificate.
+            "s3_ca_bundle_present": bool(artifact_store_data["tls_ca_chain"]),
         }
         return poddefaults_context
 

--- a/src/poddefaults/poddefault-minio.yaml.j2
+++ b/src/poddefaults/poddefault-minio.yaml.j2
@@ -23,4 +23,21 @@ spec:
          optional: false
    - name: MINIO_ENDPOINT_URL
      value: {{ s3_endpoint }}
+   {%- if s3_ca_bundle_present %}
+   - name: AWS_CA_BUNDLE
+     value: /etc/mlflow/certs/ca-bundle.pem
+   {%- endif %}
+ {%- if s3_ca_bundle_present %}
+ volumeMounts:
+   - name: s3-ca-bundle
+     mountPath: /etc/mlflow/certs
+     readOnly: true
+ volumes:
+   - name: s3-ca-bundle
+     secret:
+       secretName: {{ app_name }}-minio-artifact
+       items:
+         - key: ca-bundle.pem
+           path: ca-bundle.pem
+ {%- endif %}
 {%- endif %}

--- a/src/poddefaults/poddefault-minio.yaml.j2
+++ b/src/poddefaults/poddefault-minio.yaml.j2
@@ -1,3 +1,4 @@
+{%- if not is_proxy_mode_enabled %}
 apiVersion: kubeflow.org/v1alpha1
 kind: PodDefault
 metadata:
@@ -22,3 +23,4 @@ spec:
          optional: false
    - name: MINIO_ENDPOINT_URL
      value: {{ s3_endpoint }}
+{%- endif %}

--- a/src/poddefaults/poddefault-mlflow.yaml.j2
+++ b/src/poddefaults/poddefault-mlflow.yaml.j2
@@ -5,8 +5,10 @@ metadata:
 spec:
   desc: Allow access to MLFlow
   env:
+  {%- if not is_proxy_mode_enabled %}
   - name: MLFLOW_S3_ENDPOINT_URL
     value: {{ s3_endpoint }}
+  {%- endif %}
   - name: MLFLOW_TRACKING_URI
     value: {{ mlflow_endpoint }}
   selector:

--- a/src/secrets/mlflow-minio-artifact.j2
+++ b/src/secrets/mlflow-minio-artifact.j2
@@ -6,4 +6,8 @@ metadata:
 stringData:
   AWS_ACCESS_KEY_ID: {{ access_key }}
   AWS_SECRET_ACCESS_KEY: {{ secret_access_key }}
+{%- if s3_ca_bundle_b64 %}
+data:
+  ca-bundle.pem: {{ s3_ca_bundle_b64 }}
+{%- endif %}
 {%- endif %}

--- a/src/secrets/mlflow-minio-artifact.j2
+++ b/src/secrets/mlflow-minio-artifact.j2
@@ -1,3 +1,4 @@
+{%- if not is_proxy_mode_enabled %}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +6,4 @@ metadata:
 stringData:
   AWS_ACCESS_KEY_ID: {{ access_key }}
   AWS_SECRET_ACCESS_KEY: {{ secret_access_key }}
+{%- endif %}

--- a/tests/integration/test_charm_ambient.py
+++ b/tests/integration/test_charm_ambient.py
@@ -6,6 +6,7 @@
 
 import base64
 import logging
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -13,6 +14,7 @@ from random import choices
 from string import ascii_lowercase
 
 import lightkube
+import mlflow
 import pytest
 import requests
 import yaml
@@ -49,6 +51,7 @@ from lightkube.generic_resource import (
 )
 from lightkube.resources.core_v1 import Namespace, Secret
 from minio import Minio
+from mlflow.artifacts import download_artifacts
 from mlflow.tracking import MlflowClient
 from pytest_operator.plugin import OpsTest
 from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_fixed
@@ -159,6 +162,24 @@ async def profile_namespace(ops_test: OpsTest, lightkube_client: lightkube.Clien
         lightkube_client.delete(Namespace, profile_name)
     except ApiError:
         pass
+
+
+def _assert_resource_pruned(lightkube_client, resource, name: str, namespace: str):
+    """Assert a namespaced resource has been pruned by the resource dispatcher.
+
+    Raises a retryable AssertionError if the resource is still present, so callers can wrap this
+    in a tenacity retry to give the reconciliation loop time to propagate the change.
+    """
+    try:
+        lightkube_client.get(resource, name, namespace=namespace)
+    except ApiError as api_error:
+        if api_error.status.code == 404:
+            return
+        raise
+    raise AssertionError(
+        f"{resource.__name__} '{name}' still exists in namespace '{namespace}'; "
+        "expected it to be pruned in proxy mode"
+    )
 
 
 class TestCharm:
@@ -654,3 +675,107 @@ class TestCharm:
     ):
         """Verify the UI is still accessible through the ingress after the second ingress."""
         await assert_ui_is_accessible(ops_test)
+
+    @pytest.mark.abort_on_fail
+    async def test_enable_proxy_mode_expect_active(self, ops_test: OpsTest):
+        """Enabling serve_artifacts (proxy mode) must keep the charm active."""
+        await ops_test.model.applications[CHARM_NAME].set_config({"serve_artifacts": "true"})
+        await ops_test.model.wait_for_idle(
+            apps=[CHARM_NAME],
+            status="active",
+            raise_on_blocked=False,
+            raise_on_error=False,
+            timeout=60 * 10,
+            idle_period=60,
+        )
+        assert ops_test.model.applications[CHARM_NAME].units[0].workload_status == "active"
+
+    @retry(stop=stop_after_delay(600), wait=wait_fixed(10))
+    @pytest.mark.abort_on_fail
+    async def test_ui_is_accessible_in_proxy_mode(self, lightkube_client, ops_test: OpsTest):
+        """The tracking server UI must remain reachable after switching to proxy mode."""
+        await assert_ui_is_accessible(ops_test)
+
+    @retry(stop=stop_after_delay(600), wait=wait_fixed(10), reraise=True)
+    @pytest.mark.abort_on_fail
+    async def test_proxy_mode_updates_dispatched_manifests(
+        self, ops_test: OpsTest, lightkube_client: lightkube.Client, profile_namespace: str
+    ):
+        """In proxy mode the artifact-store credentials are no longer dispatched to users.
+
+        The minio-artifact Secret and the access-minio PodDefault (which grant direct object
+        storage access) must be pruned, while the mlflow PodDefault must remain but expose only
+        the tracking URI, since artifacts now flow through the tracking server.
+        """
+        secret_name = f"{CHARM_NAME}{SECRET_SUFFIX}"
+        _assert_resource_pruned(lightkube_client, Secret, secret_name, profile_namespace)
+
+        access_minio_poddefault_name = f"{CHARM_NAME}-access-minio"
+        _assert_resource_pruned(
+            lightkube_client, PodDefault, access_minio_poddefault_name, profile_namespace
+        )
+
+        mlflow_poddefault = lightkube_client.get(
+            PodDefault, f"{CHARM_NAME}-minio", namespace=profile_namespace
+        )
+        env_var_names = {env_var["name"] for env_var in mlflow_poddefault.spec["env"]}
+        assert "MLFLOW_TRACKING_URI" in env_var_names
+        assert "MLFLOW_S3_ENDPOINT_URL" not in env_var_names
+
+    @pytest.mark.abort_on_fail
+    async def test_client_logs_and_fetches_artifact_via_tracking_server(self, ops_test: OpsTest):
+        """A client without object-storage access must round-trip artifacts in proxy mode.
+
+        With serve_artifacts enabled, artifacts are proxied through the tracking server, so a
+        client that only knows the tracking URI (and has no S3 credentials) must be able to
+        complete a full artifact round-trip.
+        """
+        config = await ops_test.model.applications[CHARM_NAME].get_config()
+        mlflow_port = config["mlflow_port"]["value"]
+        mlflow_subprocess = subprocess.Popen(
+            [
+                "kubectl",
+                "-n",
+                f"{ops_test.model_name}",
+                "port-forward",
+                f"svc/{CHARM_NAME}",
+                f"{mlflow_port}:{mlflow_port}",
+            ]
+        )
+        time.sleep(10)  # Must wait for port-forward
+
+        # Scrub any object-storage access from the environment so that a successful artifact
+        # round-trip can only be served by the tracking server acting as a proxy.
+        object_storage_env_vars = [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "MLFLOW_S3_ENDPOINT_URL",
+            "MLFLOW_TRACKING_URI",
+        ]
+        saved_env_vars = {key: os.environ.pop(key, None) for key in object_storage_env_vars}
+        try:
+            tracking_uri = f"http://localhost:{mlflow_port}"
+            mlflow.set_tracking_uri(tracking_uri)
+
+            experiment_name = f"{TEST_EXPERIMENT_NAME}-proxy-{self.generate_random_string(6)}"
+            experiment_id = mlflow.create_experiment(experiment_name)
+            artifact_name = "proxied-artifact.txt"
+            artifact_content = f"proxied-{self.generate_random_string(8)}"
+
+            with mlflow.start_run(experiment_id=experiment_id) as run:
+                mlflow.log_text(artifact_content, artifact_name)
+                run_id = run.info.run_id
+
+            client = MlflowClient(tracking_uri=tracking_uri)
+            logged_artifacts = {artifact.path for artifact in client.list_artifacts(run_id)}
+            assert artifact_name in logged_artifacts
+
+            downloaded_path = download_artifacts(
+                run_id=run_id, artifact_path=artifact_name, tracking_uri=tracking_uri
+            )
+            assert Path(downloaded_path).read_text() == artifact_content
+        finally:
+            for key, value in saved_env_vars.items():
+                if value is not None:
+                    os.environ[key] = value
+            mlflow_subprocess.terminate()

--- a/tests/integration/test_charm_ambient.py
+++ b/tests/integration/test_charm_ambient.py
@@ -164,8 +164,8 @@ async def profile_namespace(ops_test: OpsTest, lightkube_client: lightkube.Clien
         pass
 
 
-def _assert_resource_pruned(lightkube_client, resource, name: str, namespace: str):
-    """Assert a namespaced resource has been pruned by the resource dispatcher.
+def _assert_resource_cleared(lightkube_client, resource, name: str, namespace: str):
+    """Assert a previously existing namespaced resource is cleared by resource-dispatcher.
 
     Raises a retryable AssertionError if the resource is still present, so callers can wrap this
     in a tenacity retry to give the reconciliation loop time to propagate the change.
@@ -178,7 +178,7 @@ def _assert_resource_pruned(lightkube_client, resource, name: str, namespace: st
         raise
     raise AssertionError(
         f"{resource.__name__} '{name}' still exists in namespace '{namespace}'; "
-        "expected it to be pruned in proxy mode"
+        "expected it to be cleared in proxy mode"
     )
 
 
@@ -704,14 +704,14 @@ class TestCharm:
         """In proxy mode the artifact-store credentials are no longer dispatched to users.
 
         The minio-artifact Secret and the access-minio PodDefault (which grant direct object
-        storage access) must be pruned, while the mlflow PodDefault must remain but expose only
+        storage access) must be cleared, while the mlflow PodDefault must remain but expose only
         the tracking URI, since artifacts now flow through the tracking server.
         """
         secret_name = f"{CHARM_NAME}{SECRET_SUFFIX}"
-        _assert_resource_pruned(lightkube_client, Secret, secret_name, profile_namespace)
+        _assert_resource_cleared(lightkube_client, Secret, secret_name, profile_namespace)
 
         access_minio_poddefault_name = f"{CHARM_NAME}-access-minio"
-        _assert_resource_pruned(
+        _assert_resource_cleared(
             lightkube_client, PodDefault, access_minio_poddefault_name, profile_namespace
         )
 

--- a/tests/integration/test_charm_object_storage.py
+++ b/tests/integration/test_charm_object_storage.py
@@ -531,9 +531,7 @@ class TestCharm:
             PodDefault, f"{CHARM_NAME}-access-minio", namespace=namespace
         )
         spec = access_minio_poddefault.spec
-        ca_bundle_env = next(
-            (env for env in spec["env"] if env["name"] == "AWS_CA_BUNDLE"), None
-        )
+        ca_bundle_env = next((env for env in spec["env"] if env["name"] == "AWS_CA_BUNDLE"), None)
         assert ca_bundle_env is not None
         assert ca_bundle_env["value"] == "/etc/mlflow/certs/ca-bundle.pem"
         volume = next((vol for vol in spec["volumes"] if vol["name"] == "s3-ca-bundle"), None)

--- a/tests/integration/test_charm_object_storage.py
+++ b/tests/integration/test_charm_object_storage.py
@@ -182,8 +182,8 @@ async def fetch_response(url, headers):
     return result_status, str(result_text)
 
 
-def _assert_resource_pruned(lightkube_client, resource, name: str, namespace: str):
-    """Assert a namespaced resource has been pruned by the resource dispatcher.
+def _assert_resource_cleared(lightkube_client, resource, name: str, namespace: str):
+    """Assert a previously existing namespaced resource is cleared by resource-dispatcher.
 
     Raises a retryable AssertionError if the resource is still present, so callers can wrap this
     in a tenacity retry to give the reconciliation loop time to propagate the change.
@@ -196,7 +196,7 @@ def _assert_resource_pruned(lightkube_client, resource, name: str, namespace: st
         raise
     raise AssertionError(
         f"{resource.__name__} '{name}' still exists in namespace '{namespace}'; "
-        "expected it to be pruned in proxy mode"
+        "expected it to be cleared in proxy mode"
     )
 
 
@@ -574,14 +574,14 @@ class TestCharm:
         """In proxy mode the artifact-store credentials are no longer dispatched to users.
 
         The minio-artifact Secret and the access-minio PodDefault (which grant direct object
-        storage access) must be pruned, while the mlflow PodDefault must remain but expose only
+        storage access) must be cleared, while the mlflow PodDefault must remain but expose only
         the tracking URI, since artifacts now flow through the tracking server.
         """
         secret_name = f"{CHARM_NAME}{SECRET_SUFFIX}"
-        _assert_resource_pruned(lightkube_client, Secret, secret_name, namespace)
+        _assert_resource_cleared(lightkube_client, Secret, secret_name, namespace)
 
         access_minio_poddefault_name = f"{CHARM_NAME}-access-minio"
-        _assert_resource_pruned(
+        _assert_resource_cleared(
             lightkube_client, PodDefault, access_minio_poddefault_name, namespace
         )
 

--- a/tests/integration/test_charm_object_storage.py
+++ b/tests/integration/test_charm_object_storage.py
@@ -461,6 +461,18 @@ class TestCharm:
             pod_default = lightkube_client.get(PodDefault, name, namespace=namespace)
             assert pod_default is not None
 
+        # MinIO is served over plain HTTP (no TLS CA), so no CA bundle must be embedded in the
+        # Secret nor wired into the access-minio PodDefault.
+        assert "ca-bundle.pem" not in secret.data
+        access_minio_poddefault = lightkube_client.get(
+            PodDefault, f"{CHARM_NAME}-access-minio", namespace=namespace
+        )
+        spec = access_minio_poddefault.spec
+        env_var_names = {env_var["name"] for env_var in spec["env"]}
+        assert "AWS_CA_BUNDLE" not in env_var_names
+        assert not spec.get("volumes")
+        assert not spec.get("volumeMounts")
+
     @pytest.mark.abort_on_fail
     async def test_remove_object_storage_relation_expect_blocked(self, ops_test: OpsTest):
         """Removing the object-storage relation should block the charm."""
@@ -498,13 +510,40 @@ class TestCharm:
         time.sleep(30)  # sync can take up to 10 seconds for reconciliation loop to trigger
         secret_name = f"{CHARM_NAME}{SECRET_SUFFIX}"
         secret = lightkube_client.get(Secret, secret_name, namespace=namespace)
-        assert set(secret.data.keys()) == {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"}
+        # The migrated s3-integrator advertises a TLS CA chain, so the CA bundle is embedded
+        # alongside the (randomly generated) credentials for direct client I/O.
+        assert set(secret.data.keys()) == {
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "ca-bundle.pem",
+        }
         for value in secret.data.values():
             assert value
+        ca_bundle = base64.b64decode(secret.data["ca-bundle.pem"]).decode("utf-8")
+        assert "BEGIN CERTIFICATE" in ca_bundle
         poddefaults_names = [f"{CHARM_NAME}{suffix}" for suffix in PODDEFAULTS_SUFFIXES]
         for name in poddefaults_names:
             pod_default = lightkube_client.get(PodDefault, name, namespace=namespace)
             assert pod_default is not None
+
+        # The access-minio PodDefault must now wire the CA bundle into client pods.
+        access_minio_poddefault = lightkube_client.get(
+            PodDefault, f"{CHARM_NAME}-access-minio", namespace=namespace
+        )
+        spec = access_minio_poddefault.spec
+        ca_bundle_env = next(
+            (env for env in spec["env"] if env["name"] == "AWS_CA_BUNDLE"), None
+        )
+        assert ca_bundle_env is not None
+        assert ca_bundle_env["value"] == "/etc/mlflow/certs/ca-bundle.pem"
+        volume = next((vol for vol in spec["volumes"] if vol["name"] == "s3-ca-bundle"), None)
+        assert volume is not None
+        assert volume["secret"]["secretName"] == secret_name
+        volume_mount = next(
+            (vm for vm in spec["volumeMounts"] if vm["name"] == "s3-ca-bundle"), None
+        )
+        assert volume_mount is not None
+        assert volume_mount["mountPath"] == "/etc/mlflow/certs"
 
     @pytest.mark.abort_on_fail
     async def test_enable_proxy_mode_expect_active(self, ops_test: OpsTest):

--- a/tests/integration/test_charm_object_storage.py
+++ b/tests/integration/test_charm_object_storage.py
@@ -6,6 +6,7 @@
 
 import base64
 import logging
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -14,6 +15,7 @@ from string import ascii_lowercase
 
 import aiohttp
 import lightkube
+import mlflow
 import pytest
 import requests
 import yaml
@@ -41,12 +43,14 @@ from charms_dependencies import (
     S3_INTEGRATOR,
 )
 from lightkube import codecs
+from lightkube.core.exceptions import ApiError
 from lightkube.generic_resource import (
     create_namespaced_resource,
     load_in_cluster_generic_resources,
 )
 from lightkube.resources.core_v1 import Secret, Service
 from minio import Minio
+from mlflow.artifacts import download_artifacts
 from mlflow.tracking import MlflowClient
 from pytest_operator.plugin import OpsTest
 from tenacity import retry, stop_after_delay, wait_fixed
@@ -176,6 +180,24 @@ async def fetch_response(url, headers):
             result_status = response.status
             result_text = await response.text()
     return result_status, str(result_text)
+
+
+def _assert_resource_pruned(lightkube_client, resource, name: str, namespace: str):
+    """Assert a namespaced resource has been pruned by the resource dispatcher.
+
+    Raises a retryable AssertionError if the resource is still present, so callers can wrap this
+    in a tenacity retry to give the reconciliation loop time to propagate the change.
+    """
+    try:
+        lightkube_client.get(resource, name, namespace=namespace)
+    except ApiError as api_error:
+        if api_error.status.code == 404:
+            return
+        raise
+    raise AssertionError(
+        f"{resource.__name__} '{name}' still exists in namespace '{namespace}'; "
+        "expected it to be pruned in proxy mode"
+    )
 
 
 class TestCharm:
@@ -483,3 +505,110 @@ class TestCharm:
         for name in poddefaults_names:
             pod_default = lightkube_client.get(PodDefault, name, namespace=namespace)
             assert pod_default is not None
+
+    @pytest.mark.abort_on_fail
+    async def test_enable_proxy_mode_expect_active(self, ops_test: OpsTest):
+        """Enabling serve_artifacts (proxy mode) must keep the charm active."""
+        await ops_test.model.applications[CHARM_NAME].set_config({"serve_artifacts": "true"})
+        await ops_test.model.wait_for_idle(
+            apps=[CHARM_NAME],
+            status="active",
+            raise_on_blocked=False,
+            raise_on_error=False,
+            timeout=60 * 10,
+            idle_period=60,
+        )
+        assert ops_test.model.applications[CHARM_NAME].units[0].workload_status == "active"
+
+    @retry(stop=stop_after_delay(600), wait=wait_fixed(10))
+    @pytest.mark.abort_on_fail
+    async def test_ui_is_accessible_in_proxy_mode(self, lightkube_client, ops_test: OpsTest):
+        """The tracking server UI must remain reachable after switching to proxy mode."""
+        ingress_url = get_ingress_url(lightkube_client, ops_test.model_name)
+        result_status, result_text = await fetch_response(f"{ingress_url}/mlflow/", {})
+        assert result_status == 200
+        assert len(result_text) > 0
+
+    @retry(stop=stop_after_delay(600), wait=wait_fixed(10), reraise=True)
+    @pytest.mark.abort_on_fail
+    async def test_proxy_mode_updates_dispatched_manifests(
+        self, ops_test: OpsTest, lightkube_client: lightkube.Client, namespace: str
+    ):
+        """In proxy mode the artifact-store credentials are no longer dispatched to users.
+
+        The minio-artifact Secret and the access-minio PodDefault (which grant direct object
+        storage access) must be pruned, while the mlflow PodDefault must remain but expose only
+        the tracking URI, since artifacts now flow through the tracking server.
+        """
+        secret_name = f"{CHARM_NAME}{SECRET_SUFFIX}"
+        _assert_resource_pruned(lightkube_client, Secret, secret_name, namespace)
+
+        access_minio_poddefault_name = f"{CHARM_NAME}-access-minio"
+        _assert_resource_pruned(
+            lightkube_client, PodDefault, access_minio_poddefault_name, namespace
+        )
+
+        mlflow_poddefault = lightkube_client.get(
+            PodDefault, f"{CHARM_NAME}-minio", namespace=namespace
+        )
+        env_var_names = {env_var["name"] for env_var in mlflow_poddefault.spec["env"]}
+        assert "MLFLOW_TRACKING_URI" in env_var_names
+        assert "MLFLOW_S3_ENDPOINT_URL" not in env_var_names
+
+    @pytest.mark.abort_on_fail
+    async def test_client_logs_and_fetches_artifact_via_tracking_server(self, ops_test: OpsTest):
+        """A client without object-storage access must round-trip artifacts in proxy mode.
+
+        With serve_artifacts enabled, artifacts are proxied through the tracking server, so a
+        client that only knows the tracking URI (and has no S3 credentials) must be able to
+        complete a full artifact round-trip.
+        """
+        config = await ops_test.model.applications[CHARM_NAME].get_config()
+        mlflow_port = config["mlflow_port"]["value"]
+        mlflow_subprocess = subprocess.Popen(
+            [
+                "kubectl",
+                "-n",
+                f"{ops_test.model_name}",
+                "port-forward",
+                f"svc/{CHARM_NAME}",
+                f"{mlflow_port}:{mlflow_port}",
+            ]
+        )
+        time.sleep(10)  # Must wait for port-forward
+
+        # Scrub any object-storage access from the environment so that a successful artifact
+        # round-trip can only be served by the tracking server acting as a proxy.
+        object_storage_env_vars = [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "MLFLOW_S3_ENDPOINT_URL",
+            "MLFLOW_TRACKING_URI",
+        ]
+        saved_env_vars = {key: os.environ.pop(key, None) for key in object_storage_env_vars}
+        try:
+            tracking_uri = f"http://localhost:{mlflow_port}"
+            mlflow.set_tracking_uri(tracking_uri)
+
+            experiment_name = f"{TEST_EXPERIMENT_NAME}-proxy-{self.generate_random_string(6)}"
+            experiment_id = mlflow.create_experiment(experiment_name)
+            artifact_name = "proxied-artifact.txt"
+            artifact_content = f"proxied-{self.generate_random_string(8)}"
+
+            with mlflow.start_run(experiment_id=experiment_id) as run:
+                mlflow.log_text(artifact_content, artifact_name)
+                run_id = run.info.run_id
+
+            client = MlflowClient(tracking_uri=tracking_uri)
+            logged_artifacts = {artifact.path for artifact in client.list_artifacts(run_id)}
+            assert artifact_name in logged_artifacts
+
+            downloaded_path = download_artifacts(
+                run_id=run_id, artifact_path=artifact_name, tracking_uri=tracking_uri
+            )
+            assert Path(downloaded_path).read_text() == artifact_content
+        finally:
+            for key, value in saved_env_vars.items():
+                if value is not None:
+                    os.environ[key] = value
+            mlflow_subprocess.terminate()

--- a/tests/integration/test_charm_s3.py
+++ b/tests/integration/test_charm_s3.py
@@ -11,6 +11,7 @@ kubeflow-profiles helpers/fixtures) but provides object storage through the
 """
 
 import logging
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -18,6 +19,7 @@ from random import choices
 from string import ascii_lowercase
 
 import lightkube
+import mlflow
 import pytest
 import requests
 import yaml
@@ -54,6 +56,7 @@ from lightkube.generic_resource import (
     load_in_cluster_generic_resources,
 )
 from lightkube.resources.core_v1 import Namespace, Secret
+from mlflow.artifacts import download_artifacts
 from mlflow.tracking import MlflowClient
 from pytest_operator.plugin import OpsTest
 from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_fixed
@@ -164,6 +167,24 @@ async def profile_namespace(ops_test: OpsTest, lightkube_client: lightkube.Clien
         lightkube_client.delete(Namespace, profile_name)
     except ApiError:
         pass
+
+
+def _assert_resource_pruned(lightkube_client, resource, name: str, namespace: str):
+    """Assert a namespaced resource has been pruned by the resource dispatcher.
+
+    Raises a retryable AssertionError if the resource is still present, so callers can wrap this
+    in a tenacity retry to give the reconciliation loop time to propagate the change.
+    """
+    try:
+        lightkube_client.get(resource, name, namespace=namespace)
+    except ApiError as api_error:
+        if api_error.status.code == 404:
+            return
+        raise
+    raise AssertionError(
+        f"{resource.__name__} '{name}' still exists in namespace '{namespace}'; "
+        "expected it to be pruned in proxy mode"
+    )
 
 
 class TestCharm:
@@ -616,3 +637,107 @@ class TestCharm:
     ):
         """Verify the UI is still accessible through the ingress after the second ingress."""
         await assert_ui_is_accessible(ops_test)
+
+    @pytest.mark.abort_on_fail
+    async def test_enable_proxy_mode_expect_active(self, ops_test: OpsTest):
+        """Enabling serve_artifacts (proxy mode) must keep the charm active."""
+        await ops_test.model.applications[CHARM_NAME].set_config({"serve_artifacts": "true"})
+        await ops_test.model.wait_for_idle(
+            apps=[CHARM_NAME],
+            status="active",
+            raise_on_blocked=False,
+            raise_on_error=False,
+            timeout=60 * 10,
+            idle_period=60,
+        )
+        assert ops_test.model.applications[CHARM_NAME].units[0].workload_status == "active"
+
+    @retry(stop=stop_after_delay(600), wait=wait_fixed(10))
+    @pytest.mark.abort_on_fail
+    async def test_ui_is_accessible_in_proxy_mode(self, lightkube_client, ops_test: OpsTest):
+        """The tracking server UI must remain reachable after switching to proxy mode."""
+        await assert_ui_is_accessible(ops_test)
+
+    @retry(stop=stop_after_delay(600), wait=wait_fixed(10), reraise=True)
+    @pytest.mark.abort_on_fail
+    async def test_proxy_mode_updates_dispatched_manifests(
+        self, ops_test: OpsTest, lightkube_client: lightkube.Client, profile_namespace: str
+    ):
+        """In proxy mode the artifact-store credentials are no longer dispatched to users.
+
+        The minio-artifact Secret and the access-minio PodDefault (which grant direct object
+        storage access) must be pruned, while the mlflow PodDefault must remain but expose only
+        the tracking URI, since artifacts now flow through the tracking server.
+        """
+        secret_name = f"{CHARM_NAME}{SECRET_SUFFIX}"
+        _assert_resource_pruned(lightkube_client, Secret, secret_name, profile_namespace)
+
+        access_minio_poddefault_name = f"{CHARM_NAME}-access-minio"
+        _assert_resource_pruned(
+            lightkube_client, PodDefault, access_minio_poddefault_name, profile_namespace
+        )
+
+        mlflow_poddefault = lightkube_client.get(
+            PodDefault, f"{CHARM_NAME}-minio", namespace=profile_namespace
+        )
+        env_var_names = {env_var["name"] for env_var in mlflow_poddefault.spec["env"]}
+        assert "MLFLOW_TRACKING_URI" in env_var_names
+        assert "MLFLOW_S3_ENDPOINT_URL" not in env_var_names
+
+    @pytest.mark.abort_on_fail
+    async def test_client_logs_and_fetches_artifact_via_tracking_server(self, ops_test: OpsTest):
+        """A client without object-storage access must round-trip artifacts in proxy mode.
+
+        With serve_artifacts enabled, artifacts are proxied through the tracking server, so a
+        client that only knows the tracking URI (and has no S3 credentials) must be able to
+        complete a full artifact round-trip.
+        """
+        config = await ops_test.model.applications[CHARM_NAME].get_config()
+        mlflow_port = config["mlflow_port"]["value"]
+        mlflow_subprocess = subprocess.Popen(
+            [
+                "kubectl",
+                "-n",
+                f"{ops_test.model_name}",
+                "port-forward",
+                f"svc/{CHARM_NAME}",
+                f"{mlflow_port}:{mlflow_port}",
+            ]
+        )
+        time.sleep(10)  # Must wait for port-forward
+
+        # Scrub any object-storage access from the environment so that a successful artifact
+        # round-trip can only be served by the tracking server acting as a proxy.
+        object_storage_env_vars = [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "MLFLOW_S3_ENDPOINT_URL",
+            "MLFLOW_TRACKING_URI",
+        ]
+        saved_env_vars = {key: os.environ.pop(key, None) for key in object_storage_env_vars}
+        try:
+            tracking_uri = f"http://localhost:{mlflow_port}"
+            mlflow.set_tracking_uri(tracking_uri)
+
+            experiment_name = f"{TEST_EXPERIMENT_NAME}-proxy-{self.generate_random_string(6)}"
+            experiment_id = mlflow.create_experiment(experiment_name)
+            artifact_name = "proxied-artifact.txt"
+            artifact_content = f"proxied-{self.generate_random_string(8)}"
+
+            with mlflow.start_run(experiment_id=experiment_id) as run:
+                mlflow.log_text(artifact_content, artifact_name)
+                run_id = run.info.run_id
+
+            client = MlflowClient(tracking_uri=tracking_uri)
+            logged_artifacts = {artifact.path for artifact in client.list_artifacts(run_id)}
+            assert artifact_name in logged_artifacts
+
+            downloaded_path = download_artifacts(
+                run_id=run_id, artifact_path=artifact_name, tracking_uri=tracking_uri
+            )
+            assert Path(downloaded_path).read_text() == artifact_content
+        finally:
+            for key, value in saved_env_vars.items():
+                if value is not None:
+                    os.environ[key] = value
+            mlflow_subprocess.terminate()

--- a/tests/integration/test_charm_s3.py
+++ b/tests/integration/test_charm_s3.py
@@ -170,8 +170,8 @@ async def profile_namespace(ops_test: OpsTest, lightkube_client: lightkube.Clien
         pass
 
 
-def _assert_resource_pruned(lightkube_client, resource, name: str, namespace: str):
-    """Assert a namespaced resource has been pruned by the resource dispatcher.
+def _assert_resource_cleared(lightkube_client, resource, name: str, namespace: str):
+    """Assert a previously existing namespaced resource is cleared by resource-dispatcher.
 
     Raises a retryable AssertionError if the resource is still present, so callers can wrap this
     in a tenacity retry to give the reconciliation loop time to propagate the change.
@@ -184,7 +184,7 @@ def _assert_resource_pruned(lightkube_client, resource, name: str, namespace: st
         raise
     raise AssertionError(
         f"{resource.__name__} '{name}' still exists in namespace '{namespace}'; "
-        "expected it to be pruned in proxy mode"
+        "expected it to be cleared in proxy mode"
     )
 
 
@@ -694,14 +694,14 @@ class TestCharm:
         """In proxy mode the artifact-store credentials are no longer dispatched to users.
 
         The minio-artifact Secret and the access-minio PodDefault (which grant direct object
-        storage access) must be pruned, while the mlflow PodDefault must remain but expose only
+        storage access) must be cleared, while the mlflow PodDefault must remain but expose only
         the tracking URI, since artifacts now flow through the tracking server.
         """
         secret_name = f"{CHARM_NAME}{SECRET_SUFFIX}"
-        _assert_resource_pruned(lightkube_client, Secret, secret_name, profile_namespace)
+        _assert_resource_cleared(lightkube_client, Secret, secret_name, profile_namespace)
 
         access_minio_poddefault_name = f"{CHARM_NAME}-access-minio"
-        _assert_resource_pruned(
+        _assert_resource_cleared(
             lightkube_client, PodDefault, access_minio_poddefault_name, profile_namespace
         )
 

--- a/tests/integration/test_charm_s3.py
+++ b/tests/integration/test_charm_s3.py
@@ -10,6 +10,7 @@ kubeflow-profiles helpers/fixtures) but provides object storage through the
 ``object-storage``. This is the recommended setup for any new MLflow deployments.
 """
 
+import base64
 import logging
 import os
 import subprocess
@@ -548,14 +549,43 @@ class TestCharm:
         secret_name = f"{CHARM_NAME}{SECRET_SUFFIX}"
         secret = lightkube_client.get(Secret, secret_name, namespace=profile_namespace)
         # The s3-integrator generates random credentials, so assert the expected keys are
-        # dispatched into the user namespace rather than their exact values.
-        assert set(secret.data.keys()) == {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"}
+        # dispatched into the user namespace rather than their exact values. Because this store
+        # advertises a TLS CA chain, the CA bundle is embedded too for direct client I/O.
+        assert set(secret.data.keys()) == {
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "ca-bundle.pem",
+        }
         for value in secret.data.values():
             assert value
+        # The embedded CA bundle must be a valid PEM certificate chain once base64-decoded.
+        ca_bundle = base64.b64decode(secret.data["ca-bundle.pem"]).decode("utf-8")
+        assert "BEGIN CERTIFICATE" in ca_bundle
+
         poddefaults_names = [f"{CHARM_NAME}{suffix}" for suffix in PODDEFAULTS_SUFFIXES]
         for name in poddefaults_names:
             pod_default = lightkube_client.get(PodDefault, name, namespace=profile_namespace)
             assert pod_default is not None
+
+        # The access-minio PodDefault must wire the CA bundle into client pods so their direct
+        # (non-proxy) boto3 connections trust the TLS artifact store.
+        access_minio_poddefault = lightkube_client.get(
+            PodDefault, f"{CHARM_NAME}-access-minio", namespace=profile_namespace
+        )
+        spec = access_minio_poddefault.spec
+        ca_bundle_env = next(
+            (env for env in spec["env"] if env["name"] == "AWS_CA_BUNDLE"), None
+        )
+        assert ca_bundle_env is not None
+        assert ca_bundle_env["value"] == "/etc/mlflow/certs/ca-bundle.pem"
+        volume = next((vol for vol in spec["volumes"] if vol["name"] == "s3-ca-bundle"), None)
+        assert volume is not None
+        assert volume["secret"]["secretName"] == secret_name
+        volume_mount = next(
+            (vm for vm in spec["volumeMounts"] if vm["name"] == "s3-ca-bundle"), None
+        )
+        assert volume_mount is not None
+        assert volume_mount["mountPath"] == "/etc/mlflow/certs"
 
     @pytest.mark.abort_on_fail
     async def test_deploy_and_relate_second_ingress(self, ops_test: OpsTest):

--- a/tests/integration/test_charm_s3.py
+++ b/tests/integration/test_charm_s3.py
@@ -573,9 +573,7 @@ class TestCharm:
             PodDefault, f"{CHARM_NAME}-access-minio", namespace=profile_namespace
         )
         spec = access_minio_poddefault.spec
-        ca_bundle_env = next(
-            (env for env in spec["env"] if env["name"] == "AWS_CA_BUNDLE"), None
-        )
+        ca_bundle_env = next((env for env in spec["env"] if env["name"] == "AWS_CA_BUNDLE"), None)
         assert ca_bundle_env is not None
         assert ca_bundle_env["value"] == "/etc/mlflow/certs/ca-bundle.pem"
         volume = next((vol for vol in spec["volumes"] if vol["name"] == "s3-ca-bundle"), None)

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -20,7 +20,13 @@ from ops.pebble import Service
 from ops.testing import Harness
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed
 
-from charm import PODDEFAULTS_FILES, SECRETS_FILES, MeshType, MlflowCharm
+from charm import (
+    PODDEFAULTS_FILES,
+    S3_CA_BUNDLE_CONTAINER_PATH,
+    SECRETS_FILES,
+    MeshType,
+    MlflowCharm,
+)
 
 BUCKET_NAME = "mlflow"
 CHARM_NAME = "mlflow-server"
@@ -53,6 +59,12 @@ OBJECT_STORAGE_DATA_NORMALIZED = {
     "tls_ca_chain": None,
     "is_s3": True,
 }
+
+# A sample TLS CA chain (list of PEM certificates) as delivered by an s3 store over the relation.
+S3_TLS_CA_CHAIN = [
+    "-----BEGIN CERTIFICATE-----\nZmFrZS1yb290LWNh\n-----END CERTIFICATE-----",
+    "-----BEGIN CERTIFICATE-----\nZmFrZS1pbnRlcm1lZGlhdGU=\n-----END CERTIFICATE-----",
+]
 
 RELATIONAL_DB_DATA = {
     "database": "database",
@@ -664,6 +676,94 @@ class TestCharm:
         harness.begin()
         envs = harness.charm._generate_environment()
         assert envs == expected_environment
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    @patch("charm.MlflowCharm._get_interfaces", lambda *args, **kw: None)
+    @patch("charm.MlflowCharm._get_relational_db_data", lambda *args, **kw: RELATIONAL_DB_DATA)
+    @patch("charm.MlflowCharm._get_artifact_store_data")
+    def test_generate_environment_adds_ca_bundle_for_tls_store_in_proxy_mode(
+        self,
+        mock_get_artifact_store_data,
+        harness: Harness,
+    ):
+        """A TLS artifact store in proxy mode exposes its CA to the server via AWS_CA_BUNDLE."""
+        mock_get_artifact_store_data.return_value = {
+            **OBJECT_STORAGE_DATA_NORMALIZED,
+            "bucket": "",
+            "tls_ca_chain": S3_TLS_CA_CHAIN,
+        }
+        harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: True})
+        harness.begin()
+        envs = harness.charm._generate_environment()
+        assert envs == {
+            **EXPECTED_ENVIRONMENT_PROXY_MODE,
+            "AWS_CA_BUNDLE": S3_CA_BUNDLE_CONTAINER_PATH,
+        }
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    def test_reconcile_s3_ca_bundle_pushes_bundle_in_proxy_mode_with_tls(self, harness: Harness):
+        """A TLS store in proxy mode has its CA chain pushed to the workload container."""
+        harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: True})
+        harness.begin()
+        harness.charm._container.push = MagicMock()
+
+        harness.charm._reconcile_s3_ca_bundle(
+            {**OBJECT_STORAGE_DATA_NORMALIZED, "tls_ca_chain": S3_TLS_CA_CHAIN}
+        )
+
+        harness.charm._container.push.assert_called_once_with(
+            S3_CA_BUNDLE_CONTAINER_PATH, "\n".join(S3_TLS_CA_CHAIN), make_dirs=True
+        )
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    @pytest.mark.parametrize(
+        "serve_artifacts, tls_ca_chain",
+        [
+            (True, None),
+            (False, S3_TLS_CA_CHAIN),
+            (False, None),
+        ],
+        ids=["proxy-mode-without-tls", "tls-without-proxy-mode", "neither"],
+    )
+    def test_reconcile_s3_ca_bundle_skips_push_when_not_needed(
+        self, harness: Harness, serve_artifacts, tls_ca_chain
+    ):
+        """The CA bundle is only pushed in proxy mode against a TLS store."""
+        harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: serve_artifacts})
+        harness.begin()
+        harness.charm._container.push = MagicMock()
+
+        harness.charm._reconcile_s3_ca_bundle(
+            {**OBJECT_STORAGE_DATA_NORMALIZED, "tls_ca_chain": tls_ca_chain}
+        )
+
+        harness.charm._container.push.assert_not_called()
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    def test_reconcile_s3_ca_bundle_waits_when_container_not_ready(self, harness: Harness):
+        """When the workload container is unreachable the charm waits instead of pushing."""
+        harness.set_can_connect("mlflow-server", False)
+        harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: True})
+        harness.begin()
+
+        with pytest.raises(ErrorWithStatus) as exc_info:
+            harness.charm._reconcile_s3_ca_bundle(
+                {**OBJECT_STORAGE_DATA_NORMALIZED, "tls_ca_chain": S3_TLS_CA_CHAIN}
+            )
+
+        assert exc_info.value.status == WaitingStatus("Container mlflow-server is not ready")
 
     @patch(
         "charm.KubernetesServicePatch",

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -649,27 +649,35 @@ class TestCharm:
     @patch("charm.MlflowCharm._get_relational_db_data", lambda *args, **kw: RELATIONAL_DB_DATA)
     @patch("charm.MlflowCharm._get_artifact_store_data")
     @pytest.mark.parametrize(
-        "serve_artifacts, expected_environment",
+        "serve_artifacts, tls_ca_chain, expected_environment",
         [
             # config option to serve artifacts not explicitly set -> default value -> no proxy mode:
-            (None, EXPECTED_ENVIRONMENT_NON_PROXY_MODE),
+            (None, None, EXPECTED_ENVIRONMENT_NON_PROXY_MODE),
             # config option to serve artifacts explicitly set to False -> no proxy mode:
-            (False, EXPECTED_ENVIRONMENT_NON_PROXY_MODE),
+            (False, None, EXPECTED_ENVIRONMENT_NON_PROXY_MODE),
             # config option to serve artifacts explicitly set to True -> proxy mode:
-            (True, EXPECTED_ENVIRONMENT_PROXY_MODE),
+            (True, None, EXPECTED_ENVIRONMENT_PROXY_MODE),
+            # proxy mode against a TLS store -> CA exposed to the server via AWS_CA_BUNDLE:
+            (
+                True,
+                S3_TLS_CA_CHAIN,
+                {**EXPECTED_ENVIRONMENT_PROXY_MODE, "AWS_CA_BUNDLE": S3_CA_BUNDLE_CONTAINER_PATH},
+            ),
         ],
-        ids=["default-no-proxy-mode", "no-proxy-mode", "proxy-mode"],
+        ids=["default-no-proxy-mode", "no-proxy-mode", "proxy-mode", "proxy-mode-with-tls"],
     )
     def test_generate_environment(
         self,
         mock_get_artifact_store_data,
         harness: Harness,
         serve_artifacts,
+        tls_ca_chain,
         expected_environment,
     ):
         mock_get_artifact_store_data.return_value = {
             **OBJECT_STORAGE_DATA_NORMALIZED,
             "bucket": "",
+            "tls_ca_chain": tls_ca_chain,
         }
         if serve_artifacts is not None:
             harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: serve_artifacts})
@@ -684,24 +692,33 @@ class TestCharm:
     @patch("charm.MlflowCharm._get_interfaces", lambda *args, **kw: None)
     @patch("charm.MlflowCharm._get_relational_db_data", lambda *args, **kw: RELATIONAL_DB_DATA)
     @patch("charm.MlflowCharm._get_artifact_store_data")
-    def test_generate_environment_adds_ca_bundle_for_tls_store_in_proxy_mode(
+    @pytest.mark.parametrize(
+        "serve_artifacts, tls_ca_chain, expected_environment",
+        [
+            (True, None, EXPECTED_ENVIRONMENT_PROXY_MODE),
+            (False, S3_TLS_CA_CHAIN, EXPECTED_ENVIRONMENT_NON_PROXY_MODE),
+        ],
+        ids=["proxy-mode-without-tls", "tls-without-proxy-mode"],
+    )
+    def test_generate_environment_omits_ca_bundle_when_not_needed(
         self,
         mock_get_artifact_store_data,
         harness: Harness,
+        serve_artifacts,
+        tls_ca_chain,
+        expected_environment,
     ):
-        """A TLS artifact store in proxy mode exposes its CA to the server via AWS_CA_BUNDLE."""
+        """AWS_CA_BUNDLE is only exposed for a TLS artifact store in proxy mode."""
         mock_get_artifact_store_data.return_value = {
             **OBJECT_STORAGE_DATA_NORMALIZED,
             "bucket": "",
-            "tls_ca_chain": S3_TLS_CA_CHAIN,
+            "tls_ca_chain": tls_ca_chain,
         }
-        harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: True})
+        harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: serve_artifacts})
         harness.begin()
         envs = harness.charm._generate_environment()
-        assert envs == {
-            **EXPECTED_ENVIRONMENT_PROXY_MODE,
-            "AWS_CA_BUNDLE": S3_CA_BUNDLE_CONTAINER_PATH,
-        }
+        assert "AWS_CA_BUNDLE" not in envs
+        assert envs == expected_environment
 
     @patch(
         "charm.KubernetesServicePatch",
@@ -752,18 +769,24 @@ class TestCharm:
         "charm.KubernetesServicePatch",
         lambda x, y, service_name, service_type, refresh_event: None,
     )
-    def test_reconcile_s3_ca_bundle_waits_when_container_not_ready(self, harness: Harness):
-        """When the workload container is unreachable the charm waits instead of pushing."""
+    @patch("charm.S3BucketWrapper")
+    @patch(
+        "charm.MlflowCharm._get_artifact_store_data",
+        return_value={**OBJECT_STORAGE_DATA_NORMALIZED, "tls_ca_chain": S3_TLS_CA_CHAIN},
+    )
+    def test_on_event_skips_ca_bundle_push_when_container_not_ready(
+        self, _get_artifact_store_data: MagicMock, s3_wrapper_cls: MagicMock, harness: Harness
+    ):
+        """_on_event stops before pushing the CA bundle when the workload container is down."""
         harness.set_can_connect("mlflow-server", False)
         harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: True})
         harness.begin()
+        harness.charm._container.push = MagicMock()
 
-        with pytest.raises(ErrorWithStatus) as exc_info:
-            harness.charm._reconcile_s3_ca_bundle(
-                {**OBJECT_STORAGE_DATA_NORMALIZED, "tls_ca_chain": S3_TLS_CA_CHAIN}
-            )
+        harness.charm._on_event(None)
 
-        assert exc_info.value.status == WaitingStatus("Container mlflow-server is not ready")
+        harness.charm._container.push.assert_not_called()
+        assert not isinstance(harness.charm.model.unit.status, ActiveStatus)
 
     @patch(
         "charm.KubernetesServicePatch",

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -14,17 +14,20 @@ from charms.istio_ingress_k8s.v0.istio_ingress_route import (
     IstioIngressRouteConfig,
     ProtocolType,
 )
+from charms.resource_dispatcher.v0.kubernetes_manifests import KUBERNETES_MANIFESTS_FIELD
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Service
 from ops.testing import Harness
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed
 
-from charm import MeshType, MlflowCharm
+from charm import PODDEFAULTS_FILES, SECRETS_FILES, MeshType, MlflowCharm
 
 BUCKET_NAME = "mlflow"
 CHARM_NAME = "mlflow-server"
 DEFAULT_JUJU_APP_NAME = CHARM_NAME
 MODEL_NAME = "testing"
+
+CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS = "serve_artifacts"
 
 OBJECT_STORAGE_DATA = {
     "access-key": "minio-access-key",
@@ -61,32 +64,60 @@ RELATIONAL_DB_DATA = {
 
 SECRETS_TEST_FILES = ["tests/test_data/secret.yaml.j2"]
 
-EXPECTED_ENVIRONMENT = {
+EXPECTED_SERVER_HOST = "0.0.0.0"
+EXPECTED_SERVER_METRICS_PATH = "/metrics"
+EXPECTED_SERVER_PORT = 5000
+EXPECTED_S3_ENDPOINT = (
+    f"{'https' if OBJECT_STORAGE_DATA_NORMALIZED['secure'] else 'http'}://"
+    f"{OBJECT_STORAGE_DATA_NORMALIZED['host']}:{OBJECT_STORAGE_DATA_NORMALIZED['port']}"
+)
+EXPECTED_S3_URI = f"s3://{BUCKET_NAME}"
+EXPECTED_ENVIRONMENT_NON_PROXY_MODE = {
     "MLFLOW_BACKEND_STORE_URI": "mysql+pymysql://username:lorem-ipsum@host:port/mlflow",
-    "MLFLOW_DEFAULT_ARTIFACT_ROOT": f"s3://{BUCKET_NAME}",
-    "MLFLOW_EXPOSE_PROMETHEUS": "/metrics",
-    "MLFLOW_HOST": "0.0.0.0",
-    "MLFLOW_PORT": 5000,
+    "MLFLOW_DEFAULT_ARTIFACT_ROOT": EXPECTED_S3_URI,
+    "MLFLOW_EXPOSE_PROMETHEUS": EXPECTED_SERVER_METRICS_PATH,
+    "MLFLOW_HOST": EXPECTED_SERVER_HOST,
+    "MLFLOW_PORT": EXPECTED_SERVER_PORT,
     "MLFLOW_SERVE_ARTIFACTS": "False",
 }
-EXPECTED_SERVICE = {
-    "mlflow-server": Service(
-        "mlflow-server",
-        raw={
-            "summary": "Entrypoint of mlflow-server image",
-            "startup": "enabled",
-            "override": "replace",
-            "command": "mlflow server",
-            "environment": EXPECTED_ENVIRONMENT,
-        },
-    )
+EXPECTED_ENVIRONMENT_PROXY_MODE = {
+    "MLFLOW_BACKEND_STORE_URI": "mysql+pymysql://username:lorem-ipsum@host:port/mlflow",
+    "MLFLOW_EXPOSE_PROMETHEUS": EXPECTED_SERVER_METRICS_PATH,
+    "MLFLOW_HOST": EXPECTED_SERVER_HOST,
+    "MLFLOW_PORT": EXPECTED_SERVER_PORT,
+    "AWS_ACCESS_KEY_ID": OBJECT_STORAGE_DATA_NORMALIZED["access_key"],
+    "AWS_SECRET_ACCESS_KEY": OBJECT_STORAGE_DATA_NORMALIZED["secret_key"],
+    "MLFLOW_ARTIFACTS_DESTINATION": EXPECTED_S3_URI,
+    "MLFLOW_DEFAULT_ARTIFACT_ROOT": "mlflow-artifacts:/",
+    "MLFLOW_S3_ENDPOINT_URL": EXPECTED_S3_ENDPOINT,
+    "MLFLOW_SERVE_ARTIFACTS": "True",
 }
+
+
+def build_expected_pebble_service_plan(environment_variables: dict) -> dict:
+    """Build the expected pebble service plan for the given environment variables."""
+    return {
+        "mlflow-server": Service(
+            "mlflow-server",
+            raw={
+                "summary": "Entrypoint of mlflow-server image",
+                "startup": "enabled",
+                "override": "replace",
+                "command": "mlflow server",
+                "environment": environment_variables,
+            },
+        )
+    }
+
+
 EXPECTED_INGRESS_PATH_MATCHED_PREFIX = "/mlflow/"
 EXPECTED_INGRESS_PATH_REWRITTEN_PREFIX = "/"
-EXPECTED_K8S_SERVICE_HTTP_PORT = 5000
+EXPECTED_K8S_SERVICE_HTTP_PORT = EXPECTED_SERVER_PORT
 RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE = "istio-ingress-route"
 RELATION_ENDPOINT_FOR_INGRESS_IN_SIDECAR_MODE = "ingress"
 RELATION_ENDPOINT_FOR_SERVICE_MESH = "service-mesh"
+RELATION_ENDPOINT_FOR_SECRETS = "secrets"
+RELATION_ENDPOINT_FOR_PODDEFAULTS = "pod-defaults"
 
 INGRESS_DATA = {
     "prefix": EXPECTED_INGRESS_PATH_MATCHED_PREFIX,
@@ -95,6 +126,94 @@ INGRESS_DATA = {
     "namespace": MODEL_NAME,
     "port": EXPECTED_K8S_SERVICE_HTTP_PORT,
 }
+
+# Rendered manifests expected from the SECRETS_FILES and PODDEFAULTS_FILES templates:
+EXPECTED_MLFLOW_ENDPOINT = (
+    f"http://{CHARM_NAME}.{MODEL_NAME}.svc.cluster.local:{EXPECTED_K8S_SERVICE_HTTP_PORT}"
+)
+EXPECTED_SECRET_MANIFEST = {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {"name": f"{CHARM_NAME}-minio-artifact"},
+    "stringData": {"AWS_ACCESS_KEY_ID": "a", "AWS_SECRET_ACCESS_KEY": "s"},
+}
+EXPECTED_MINIO_PODDEFAULT_MANIFEST = {
+    "apiVersion": "kubeflow.org/v1alpha1",
+    "kind": "PodDefault",
+    "metadata": {"name": f"{CHARM_NAME}-access-minio"},
+    "spec": {
+        "desc": "Allow access to Minio",
+        "selector": {"matchLabels": {"access-minio": "true"}},
+        "env": [
+            {
+                "name": "AWS_ACCESS_KEY_ID",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "name": f"{CHARM_NAME}-minio-artifact",
+                        "key": "AWS_ACCESS_KEY_ID",
+                        "optional": False,
+                    }
+                },
+            },
+            {
+                "name": "AWS_SECRET_ACCESS_KEY",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "name": f"{CHARM_NAME}-minio-artifact",
+                        "key": "AWS_SECRET_ACCESS_KEY",
+                        "optional": False,
+                    }
+                },
+            },
+            {"name": "MINIO_ENDPOINT_URL", "value": EXPECTED_S3_ENDPOINT},
+        ],
+    },
+}
+EXPECTED_MLFLOW_PODDEFAULT_MANIFEST_NON_PROXY_MODE = {
+    "apiVersion": "kubeflow.org/v1alpha1",
+    "kind": "PodDefault",
+    "metadata": {"name": f"{CHARM_NAME}-minio"},
+    "spec": {
+        "desc": "Allow access to MLFlow",
+        "env": [
+            {"name": "MLFLOW_S3_ENDPOINT_URL", "value": EXPECTED_S3_ENDPOINT},
+            {"name": "MLFLOW_TRACKING_URI", "value": EXPECTED_MLFLOW_ENDPOINT},
+        ],
+        "selector": {"matchLabels": {"mlflow-server-minio": "true"}},
+    },
+}
+EXPECTED_MLFLOW_PODDEFAULT_MANIFEST_PROXY_MODE = {
+    "apiVersion": "kubeflow.org/v1alpha1",
+    "kind": "PodDefault",
+    "metadata": {"name": f"{CHARM_NAME}-minio"},
+    "spec": {
+        "desc": "Allow access to MLFlow",
+        "env": [
+            {"name": "MLFLOW_TRACKING_URI", "value": EXPECTED_MLFLOW_ENDPOINT},
+        ],
+        "selector": {"matchLabels": {"mlflow-server-minio": "true"}},
+    },
+}
+
+
+def build_secrets_context(is_proxy_mode_enabled: bool) -> dict:
+    """Build a rendering context with only the keys the secrets templates require."""
+    return {
+        "app_name": CHARM_NAME,
+        "access_key": "a",
+        "secret_access_key": "s",
+        "is_proxy_mode_enabled": is_proxy_mode_enabled,
+    }
+
+
+def build_poddefaults_context(is_proxy_mode_enabled: bool) -> dict:
+    """Build a rendering context with only the keys the poddefaults templates require."""
+    return {
+        "app_name": CHARM_NAME,
+        "s3_endpoint": EXPECTED_S3_ENDPOINT,
+        "mlflow_endpoint": EXPECTED_MLFLOW_ENDPOINT,
+        "is_proxy_mode_enabled": is_proxy_mode_enabled,
+    }
 
 
 @pytest.fixture(scope="function")
@@ -113,7 +232,7 @@ def harness() -> Harness:
     return harness
 
 
-def add_relation(harness: harness, relation_endpoint: str) -> tuple[int, str]:
+def add_relation(harness: Harness, relation_endpoint: str) -> tuple[int, str]:
     """Add the given relation to the charm unit, using a random name for the remote application."""
     relation_provider_app_name = f"app-for-{relation_endpoint}"
 
@@ -486,13 +605,19 @@ class TestCharm:
     @patch(
         "charm.MlflowCharm.service_environment",
         new_callable=PropertyMock,
-        return_value=EXPECTED_ENVIRONMENT,
+    )
+    @pytest.mark.parametrize(
+        "expected_environment",
+        [EXPECTED_ENVIRONMENT_PROXY_MODE, EXPECTED_ENVIRONMENT_NON_PROXY_MODE],
+        ids=["proxy-mode", "no-proxy-mode"],
     )
     def test_update_layer_success(
         self,
-        _: MagicMock,
+        mock_service_environment: PropertyMock,
         harness: Harness,
+        expected_environment,
     ):
+        mock_service_environment.return_value = expected_environment
         harness.begin()
         update_layer(
             harness.charm._container_name,
@@ -500,7 +625,9 @@ class TestCharm:
             harness.charm._mlflow_server_layer,
             harness.charm.logger,
         )
-        assert harness.charm.container.get_plan().services == EXPECTED_SERVICE
+        assert harness.charm.container.get_plan().services == build_expected_pebble_service_plan(
+            expected_environment
+        )
 
     @patch(
         "charm.KubernetesServicePatch",
@@ -509,18 +636,106 @@ class TestCharm:
     @patch("charm.MlflowCharm._get_interfaces", lambda *args, **kw: None)
     @patch("charm.MlflowCharm._get_relational_db_data", lambda *args, **kw: RELATIONAL_DB_DATA)
     @patch("charm.MlflowCharm._get_artifact_store_data")
+    @pytest.mark.parametrize(
+        "serve_artifacts, expected_environment",
+        [
+            # config option to serve artifacts not explicitly set -> default value -> no proxy mode:
+            (None, EXPECTED_ENVIRONMENT_NON_PROXY_MODE),
+            # config option to serve artifacts explicitly set to False -> no proxy mode:
+            (False, EXPECTED_ENVIRONMENT_NON_PROXY_MODE),
+            # config option to serve artifacts explicitly set to True -> proxy mode:
+            (True, EXPECTED_ENVIRONMENT_PROXY_MODE),
+        ],
+        ids=["default-no-proxy-mode", "no-proxy-mode", "proxy-mode"],
+    )
     def test_generate_environment(
         self,
         mock_get_artifact_store_data,
         harness: Harness,
+        serve_artifacts,
+        expected_environment,
     ):
         mock_get_artifact_store_data.return_value = {
             **OBJECT_STORAGE_DATA_NORMALIZED,
             "bucket": "",
         }
+        if serve_artifacts is not None:
+            harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: serve_artifacts})
         harness.begin()
         envs = harness.charm._generate_environment()
-        assert envs == EXPECTED_ENVIRONMENT
+        assert envs == expected_environment
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    @pytest.mark.parametrize("serve_artifacts", [True, False], ids=["proxy-mode", "no-proxy-mode"])
+    def test_proxy_mode(self, harness: Harness, serve_artifacts):
+        """Test that the proxy_mode property mirrors the serve_artifacts config option."""
+        harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: serve_artifacts})
+        harness.begin()
+        assert harness.charm.proxy_mode is serve_artifacts
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    @pytest.mark.parametrize(
+        "secure, expected_scheme",
+        [(False, "http"), (True, "https")],
+        ids=["insecure", "secure"],
+    )
+    def test_extract_s3_endpoint(self, harness: Harness, secure, expected_scheme):
+        """Test that the S3 endpoint URL is correctly extracted from artifact store data."""
+        harness.begin()
+        artifact_store_data = {**OBJECT_STORAGE_DATA_NORMALIZED, "secure": secure}
+        endpoint = harness.charm._extract_s3_endpoint(artifact_store_data)
+        assert endpoint == (
+            f"{expected_scheme}://"
+            f"{OBJECT_STORAGE_DATA_NORMALIZED['host']}:{OBJECT_STORAGE_DATA_NORMALIZED['port']}"
+        )
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    @patch("charm.MlflowCharm._get_interfaces", lambda *args, **kw: None)
+    @patch(
+        "charm.MlflowCharm._get_artifact_store_data",
+        return_value=OBJECT_STORAGE_DATA_NORMALIZED,
+    )
+    @pytest.mark.parametrize("serve_artifacts", [True, False], ids=["proxy-mode", "no-proxy-mode"])
+    def test_secrets_context(self, _: MagicMock, harness: Harness, serve_artifacts):
+        """Test that the context for secrets carries the expected data."""
+        harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: serve_artifacts})
+        harness.begin()
+        context = harness.charm.secrets_context
+        assert context["app_name"] == DEFAULT_JUJU_APP_NAME
+        assert context["access_key"] == OBJECT_STORAGE_DATA_NORMALIZED["access_key"]
+        assert context["secret_access_key"] == OBJECT_STORAGE_DATA_NORMALIZED["secret_key"]
+        assert context["is_proxy_mode_enabled"] is serve_artifacts
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    @patch("charm.MlflowCharm._get_interfaces", lambda *args, **kw: None)
+    @patch(
+        "charm.MlflowCharm._get_artifact_store_data",
+        return_value=OBJECT_STORAGE_DATA_NORMALIZED,
+    )
+    @pytest.mark.parametrize("serve_artifacts", [True, False], ids=["proxy-mode", "no-proxy-mode"])
+    def test_poddefaults_context(self, _: MagicMock, harness: Harness, serve_artifacts):
+        """Test that the context for poddefaults carries the expected data."""
+        harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: serve_artifacts})
+        harness.begin()
+        context = harness.charm.poddefaults_context
+        assert context["app_name"] == DEFAULT_JUJU_APP_NAME
+        assert context["s3_endpoint"] == EXPECTED_S3_ENDPOINT
+        assert context["mlflow_endpoint"] == (
+            f"http://{CHARM_NAME}.{MODEL_NAME}.svc.cluster.local:{EXPECTED_K8S_SERVICE_HTTP_PORT}"
+        )
+        assert context["is_proxy_mode_enabled"] is serve_artifacts
 
     @patch(
         "charm.KubernetesServicePatch",
@@ -543,6 +758,48 @@ class TestCharm:
         "charm.KubernetesServicePatch",
         lambda x, y, service_name, service_type, refresh_event: None,
     )
+    @pytest.mark.parametrize(
+        "manifest_files, context, expected_manifests",
+        [
+            (
+                SECRETS_FILES,
+                build_secrets_context(is_proxy_mode_enabled=False),
+                [EXPECTED_SECRET_MANIFEST],
+            ),
+            (SECRETS_FILES, build_secrets_context(is_proxy_mode_enabled=True), []),
+            (
+                PODDEFAULTS_FILES,
+                build_poddefaults_context(is_proxy_mode_enabled=False),
+                [
+                    EXPECTED_MINIO_PODDEFAULT_MANIFEST,
+                    EXPECTED_MLFLOW_PODDEFAULT_MANIFEST_NON_PROXY_MODE,
+                ],
+            ),
+            (
+                PODDEFAULTS_FILES,
+                build_poddefaults_context(is_proxy_mode_enabled=True),
+                [EXPECTED_MLFLOW_PODDEFAULT_MANIFEST_PROXY_MODE],
+            ),
+        ],
+        ids=[
+            "secrets-proxy-disabled-renders-secret",
+            "secrets-proxy-enabled-skips-empty-document",
+            "poddefaults-proxy-disabled-renders-both",
+            "poddefaults-proxy-enabled-skips-minio-poddefault",
+        ],
+    )
+    def test_create_manifests_skips_empty_documents(
+        self, harness: Harness, manifest_files, context, expected_manifests
+    ):
+        """Test that templates rendering to empty documents are skipped."""
+        harness.begin()
+        manifests_items = harness.charm._create_manifests(manifest_files, context)
+        assert [item.manifest for item in manifests_items] == expected_manifests
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
     @patch("charm.MlflowCharm._create_manifests")
     @patch("charm.MlflowCharm.secrets_manifests_wrapper")
     def test_send_manifests(
@@ -554,6 +811,73 @@ class TestCharm:
         harness.begin()
         harness.charm._send_manifests({}, [""], secrets_manifests_wrapper)
         secrets_manifests_wrapper.send_data.assert_called_once()
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    @pytest.mark.parametrize(
+        "relation_endpoint, wrapper_attribute, manifest_files, context, expected_manifests",
+        [
+            (
+                RELATION_ENDPOINT_FOR_SECRETS,
+                "secrets_manifests_wrapper",
+                SECRETS_FILES,
+                build_secrets_context(is_proxy_mode_enabled=False),
+                [EXPECTED_SECRET_MANIFEST],
+            ),
+            (
+                RELATION_ENDPOINT_FOR_SECRETS,
+                "secrets_manifests_wrapper",
+                SECRETS_FILES,
+                build_secrets_context(is_proxy_mode_enabled=True),
+                [],
+            ),
+            (
+                RELATION_ENDPOINT_FOR_PODDEFAULTS,
+                "poddefaults_manifests_wrapper",
+                PODDEFAULTS_FILES,
+                build_poddefaults_context(is_proxy_mode_enabled=False),
+                [
+                    EXPECTED_MINIO_PODDEFAULT_MANIFEST,
+                    EXPECTED_MLFLOW_PODDEFAULT_MANIFEST_NON_PROXY_MODE,
+                ],
+            ),
+            (
+                RELATION_ENDPOINT_FOR_PODDEFAULTS,
+                "poddefaults_manifests_wrapper",
+                PODDEFAULTS_FILES,
+                build_poddefaults_context(is_proxy_mode_enabled=True),
+                [EXPECTED_MLFLOW_PODDEFAULT_MANIFEST_PROXY_MODE],
+            ),
+        ],
+        ids=[
+            "secrets-proxy-disabled-applies-secret",
+            "secrets-proxy-enabled-applies-nothing",
+            "poddefaults-proxy-disabled-applies-both",
+            "poddefaults-proxy-enabled-applies-mlflow-poddefault-only",
+        ],
+    )
+    def test_send_manifests_applies_rendered_manifests_to_relation(
+        self,
+        harness: Harness,
+        relation_endpoint,
+        wrapper_attribute,
+        manifest_files,
+        context,
+        expected_manifests,
+    ):
+        """Test that the rendered manifests are written verbatim to the relation databag."""
+        relation_id, _ = add_relation(harness, relation_endpoint=relation_endpoint)
+        harness.begin()
+
+        harness.charm._send_manifests(
+            context, manifest_files, getattr(harness.charm, wrapper_attribute)
+        )
+
+        application_databag = harness.get_relation_data(relation_id, harness.charm.app.name)
+        applied_manifests = json.loads(application_databag[KUBERNETES_MANIFESTS_FIELD])
+        assert applied_manifests == expected_manifests
 
     @patch(
         "charm.KubernetesServicePatch",

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -989,9 +989,7 @@ class TestCharm:
             ),
             (
                 PODDEFAULTS_FILES,
-                build_poddefaults_context(
-                    is_proxy_mode_enabled=False, s3_ca_bundle_present=True
-                ),
+                build_poddefaults_context(is_proxy_mode_enabled=False, s3_ca_bundle_present=True),
                 [
                     EXPECTED_MINIO_PODDEFAULT_MANIFEST_WITH_CA,
                     EXPECTED_MLFLOW_PODDEFAULT_MANIFEST_NON_PROXY_MODE,

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import base64
 import json
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -65,6 +66,9 @@ S3_TLS_CA_CHAIN = [
     "-----BEGIN CERTIFICATE-----\nZmFrZS1yb290LWNh\n-----END CERTIFICATE-----",
     "-----BEGIN CERTIFICATE-----\nZmFrZS1pbnRlcm1lZGlhdGU=\n-----END CERTIFICATE-----",
 ]
+
+# The same CA chain as embedded (joined + base64-encoded) into the artifact-store Secret's data.
+EXPECTED_S3_CA_BUNDLE_B64 = base64.b64encode("\n".join(S3_TLS_CA_CHAIN).encode()).decode()
 
 RELATIONAL_DB_DATA = {
     "database": "database",
@@ -149,6 +153,11 @@ EXPECTED_SECRET_MANIFEST = {
     "metadata": {"name": f"{CHARM_NAME}-minio-artifact"},
     "stringData": {"AWS_ACCESS_KEY_ID": "a", "AWS_SECRET_ACCESS_KEY": "s"},
 }
+# Secret variant for a TLS artifact store: the CA bundle is embedded (base64) under `data`.
+EXPECTED_SECRET_MANIFEST_WITH_CA = {
+    **EXPECTED_SECRET_MANIFEST,
+    "data": {"ca-bundle.pem": EXPECTED_S3_CA_BUNDLE_B64},
+}
 EXPECTED_MINIO_PODDEFAULT_MANIFEST = {
     "apiVersion": "kubeflow.org/v1alpha1",
     "kind": "PodDefault",
@@ -181,6 +190,30 @@ EXPECTED_MINIO_PODDEFAULT_MANIFEST = {
         ],
     },
 }
+# access-minio PodDefault variant for a TLS artifact store: the CA bundle Secret key is mounted
+# read-only into client pods and AWS_CA_BUNDLE points boto3 at it.
+EXPECTED_MINIO_PODDEFAULT_MANIFEST_WITH_CA = {
+    **EXPECTED_MINIO_PODDEFAULT_MANIFEST,
+    "spec": {
+        **EXPECTED_MINIO_PODDEFAULT_MANIFEST["spec"],
+        "env": [
+            *EXPECTED_MINIO_PODDEFAULT_MANIFEST["spec"]["env"],
+            {"name": "AWS_CA_BUNDLE", "value": "/etc/mlflow/certs/ca-bundle.pem"},
+        ],
+        "volumeMounts": [
+            {"name": "s3-ca-bundle", "mountPath": "/etc/mlflow/certs", "readOnly": True},
+        ],
+        "volumes": [
+            {
+                "name": "s3-ca-bundle",
+                "secret": {
+                    "secretName": f"{CHARM_NAME}-minio-artifact",
+                    "items": [{"key": "ca-bundle.pem", "path": "ca-bundle.pem"}],
+                },
+            },
+        ],
+    },
+}
 EXPECTED_MLFLOW_PODDEFAULT_MANIFEST_NON_PROXY_MODE = {
     "apiVersion": "kubeflow.org/v1alpha1",
     "kind": "PodDefault",
@@ -208,23 +241,27 @@ EXPECTED_MLFLOW_PODDEFAULT_MANIFEST_PROXY_MODE = {
 }
 
 
-def build_secrets_context(is_proxy_mode_enabled: bool) -> dict:
+def build_secrets_context(is_proxy_mode_enabled: bool, s3_ca_bundle_b64: str = "") -> dict:
     """Build a rendering context with only the keys the secrets templates require."""
     return {
         "app_name": CHARM_NAME,
         "access_key": "a",
         "secret_access_key": "s",
         "is_proxy_mode_enabled": is_proxy_mode_enabled,
+        "s3_ca_bundle_b64": s3_ca_bundle_b64,
     }
 
 
-def build_poddefaults_context(is_proxy_mode_enabled: bool) -> dict:
+def build_poddefaults_context(
+    is_proxy_mode_enabled: bool, s3_ca_bundle_present: bool = False
+) -> dict:
     """Build a rendering context with only the keys the poddefaults templates require."""
     return {
         "app_name": CHARM_NAME,
         "s3_endpoint": EXPECTED_S3_ENDPOINT,
         "mlflow_endpoint": EXPECTED_MLFLOW_ENDPOINT,
         "is_proxy_mode_enabled": is_proxy_mode_enabled,
+        "s3_ca_bundle_present": s3_ca_bundle_present,
     }
 
 
@@ -840,13 +877,26 @@ class TestCharm:
         lambda x, y, service_name, service_type, refresh_event: None,
     )
     @patch("charm.MlflowCharm._get_interfaces", lambda *args, **kw: None)
-    @patch(
-        "charm.MlflowCharm._get_artifact_store_data",
-        return_value=OBJECT_STORAGE_DATA_NORMALIZED,
-    )
+    @patch("charm.MlflowCharm._get_artifact_store_data")
     @pytest.mark.parametrize("serve_artifacts", [True, False], ids=["proxy-mode", "no-proxy-mode"])
-    def test_secrets_context(self, _: MagicMock, harness: Harness, serve_artifacts):
+    @pytest.mark.parametrize(
+        "tls_ca_chain, expected_ca_bundle_b64",
+        [(None, ""), (S3_TLS_CA_CHAIN, EXPECTED_S3_CA_BUNDLE_B64)],
+        ids=["without-tls", "with-tls"],
+    )
+    def test_secrets_context(
+        self,
+        mock_get_artifact_store_data: MagicMock,
+        harness: Harness,
+        serve_artifacts,
+        tls_ca_chain,
+        expected_ca_bundle_b64,
+    ):
         """Test that the context for secrets carries the expected data."""
+        mock_get_artifact_store_data.return_value = {
+            **OBJECT_STORAGE_DATA_NORMALIZED,
+            "tls_ca_chain": tls_ca_chain,
+        }
         harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: serve_artifacts})
         harness.begin()
         context = harness.charm.secrets_context
@@ -854,19 +904,33 @@ class TestCharm:
         assert context["access_key"] == OBJECT_STORAGE_DATA_NORMALIZED["access_key"]
         assert context["secret_access_key"] == OBJECT_STORAGE_DATA_NORMALIZED["secret_key"]
         assert context["is_proxy_mode_enabled"] is serve_artifacts
+        assert context["s3_ca_bundle_b64"] == expected_ca_bundle_b64
 
     @patch(
         "charm.KubernetesServicePatch",
         lambda x, y, service_name, service_type, refresh_event: None,
     )
     @patch("charm.MlflowCharm._get_interfaces", lambda *args, **kw: None)
-    @patch(
-        "charm.MlflowCharm._get_artifact_store_data",
-        return_value=OBJECT_STORAGE_DATA_NORMALIZED,
-    )
+    @patch("charm.MlflowCharm._get_artifact_store_data")
     @pytest.mark.parametrize("serve_artifacts", [True, False], ids=["proxy-mode", "no-proxy-mode"])
-    def test_poddefaults_context(self, _: MagicMock, harness: Harness, serve_artifacts):
+    @pytest.mark.parametrize(
+        "tls_ca_chain, expected_ca_bundle_present",
+        [(None, False), (S3_TLS_CA_CHAIN, True)],
+        ids=["without-tls", "with-tls"],
+    )
+    def test_poddefaults_context(
+        self,
+        mock_get_artifact_store_data: MagicMock,
+        harness: Harness,
+        serve_artifacts,
+        tls_ca_chain,
+        expected_ca_bundle_present,
+    ):
         """Test that the context for poddefaults carries the expected data."""
+        mock_get_artifact_store_data.return_value = {
+            **OBJECT_STORAGE_DATA_NORMALIZED,
+            "tls_ca_chain": tls_ca_chain,
+        }
         harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: serve_artifacts})
         harness.begin()
         context = harness.charm.poddefaults_context
@@ -876,6 +940,7 @@ class TestCharm:
             f"http://{CHARM_NAME}.{MODEL_NAME}.svc.cluster.local:{EXPECTED_K8S_SERVICE_HTTP_PORT}"
         )
         assert context["is_proxy_mode_enabled"] is serve_artifacts
+        assert context["s3_ca_bundle_present"] is expected_ca_bundle_present
 
     @patch(
         "charm.KubernetesServicePatch",
@@ -906,6 +971,13 @@ class TestCharm:
                 build_secrets_context(is_proxy_mode_enabled=False),
                 [EXPECTED_SECRET_MANIFEST],
             ),
+            (
+                SECRETS_FILES,
+                build_secrets_context(
+                    is_proxy_mode_enabled=False, s3_ca_bundle_b64=EXPECTED_S3_CA_BUNDLE_B64
+                ),
+                [EXPECTED_SECRET_MANIFEST_WITH_CA],
+            ),
             (SECRETS_FILES, build_secrets_context(is_proxy_mode_enabled=True), []),
             (
                 PODDEFAULTS_FILES,
@@ -917,14 +989,26 @@ class TestCharm:
             ),
             (
                 PODDEFAULTS_FILES,
+                build_poddefaults_context(
+                    is_proxy_mode_enabled=False, s3_ca_bundle_present=True
+                ),
+                [
+                    EXPECTED_MINIO_PODDEFAULT_MANIFEST_WITH_CA,
+                    EXPECTED_MLFLOW_PODDEFAULT_MANIFEST_NON_PROXY_MODE,
+                ],
+            ),
+            (
+                PODDEFAULTS_FILES,
                 build_poddefaults_context(is_proxy_mode_enabled=True),
                 [EXPECTED_MLFLOW_PODDEFAULT_MANIFEST_PROXY_MODE],
             ),
         ],
         ids=[
             "secrets-proxy-disabled-renders-secret",
+            "secrets-proxy-disabled-with-tls-embeds-ca-bundle",
             "secrets-proxy-enabled-skips-empty-document",
             "poddefaults-proxy-disabled-renders-both",
+            "poddefaults-proxy-disabled-with-tls-mounts-ca-bundle",
             "poddefaults-proxy-enabled-skips-minio-poddefault",
         ],
     )

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -649,22 +649,37 @@ class TestCharm:
     @patch("charm.MlflowCharm._get_relational_db_data", lambda *args, **kw: RELATIONAL_DB_DATA)
     @patch("charm.MlflowCharm._get_artifact_store_data")
     @pytest.mark.parametrize(
-        "serve_artifacts, tls_ca_chain, expected_environment",
+        "serve_artifacts, tls_ca_chain, region, expected_environment",
         [
             # config option to serve artifacts not explicitly set -> default value -> no proxy mode:
-            (None, None, EXPECTED_ENVIRONMENT_NON_PROXY_MODE),
+            (None, None, "", EXPECTED_ENVIRONMENT_NON_PROXY_MODE),
             # config option to serve artifacts explicitly set to False -> no proxy mode:
-            (False, None, EXPECTED_ENVIRONMENT_NON_PROXY_MODE),
+            (False, None, "", EXPECTED_ENVIRONMENT_NON_PROXY_MODE),
             # config option to serve artifacts explicitly set to True -> proxy mode:
-            (True, None, EXPECTED_ENVIRONMENT_PROXY_MODE),
+            (True, None, "", EXPECTED_ENVIRONMENT_PROXY_MODE),
             # proxy mode against a TLS store -> CA exposed to the server via AWS_CA_BUNDLE:
             (
                 True,
                 S3_TLS_CA_CHAIN,
+                "",
                 {**EXPECTED_ENVIRONMENT_PROXY_MODE, "AWS_CA_BUNDLE": S3_CA_BUNDLE_CONTAINER_PATH},
             ),
+            # proxy mode against a store advertising a region -> region exposed to the server via
+            # AWS_DEFAULT_REGION:
+            (
+                True,
+                None,
+                "us-east-1",
+                {**EXPECTED_ENVIRONMENT_PROXY_MODE, "AWS_DEFAULT_REGION": "us-east-1"},
+            ),
         ],
-        ids=["default-no-proxy-mode", "no-proxy-mode", "proxy-mode", "proxy-mode-with-tls"],
+        ids=[
+            "default-no-proxy-mode",
+            "no-proxy-mode",
+            "proxy-mode",
+            "proxy-mode-with-tls",
+            "proxy-mode-with-region",
+        ],
     )
     def test_generate_environment(
         self,
@@ -672,12 +687,14 @@ class TestCharm:
         harness: Harness,
         serve_artifacts,
         tls_ca_chain,
+        region,
         expected_environment,
     ):
         mock_get_artifact_store_data.return_value = {
             **OBJECT_STORAGE_DATA_NORMALIZED,
             "bucket": "",
             "tls_ca_chain": tls_ca_chain,
+            "region": region,
         }
         if serve_artifacts is not None:
             harness.update_config({CONFIG_OPTION_NAME_FOR_SERVE_ARTIFACTS: serve_artifacts})


### PR DESCRIPTION
resolves https://github.com/canonical/mlflow-operator/issues/287

Also, in addition to parametrizing proxy mode, this pull request also addresses a lack of the previous integration with S3 storage where some necessary environment variables for the region and for the CA chain of S3 storage were not passed to clients (when in non-proxy mode) when those settings were passed as non-empty data by the S3 integration, in order not to see client requests fail in such cases.

To recap:
- when in proxy mode (config option `serve_artifcts` = `true`):
  - tracking server (re)run for direct S3 access
  - Secrets and PodDefaults updated to transfer S3 access to clients
- when not (default, as it always was in the past, config option `serve_artifcts` = `false`):
  - tracking server (re)run without S3 access
  - Secrets and PodDefaults updated to revoke S3 access from clients

note: **NOT** to be backported to MLflow 2, only available in MLflow 3