### PR TITLE
chore: Use 2/stable channel for s3-integrator in integration tests

### DIFF
--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -30,7 +30,7 @@ MYSQL_K8S = CharmSpec(
     charm="mysql-k8s", channel="8.0/stable", config={"profile": "testing"}, trust=True
 )
 RESOURCE_DISPATCHER = CharmSpec(charm="resource-dispatcher", channel="latest/edge", trust=True)
-S3_INTEGRATOR = CharmSpec(charm="s3-integrator", channel="2/edge", trust=False)
+S3_INTEGRATOR = CharmSpec(charm="s3-integrator", channel="2/stable", trust=False)
 KUBEFLOW_PROFILES = CharmSpec(
     charm="kubeflow-profiles",
     channel="latest/edge",


### PR DESCRIPTION
## Summary
This PR updates the charm dependency for `s3-integrator` in all integration tests to use `2/stable`.

Base issue: https://github.com/canonical/bundle-kubeflow/issues/1456