### PR TITLE
fix: Add s3-credentials relation to terraform module

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -12,14 +12,16 @@ output "provides" {
 
 output "requires" {
   value = {
-    dashboard_links  = "dashboard-links",
-    ingress          = "ingress",
-    object_storage   = "object-storage",
-    pod_defaults     = "pod-defaults",
-    relational_db    = "relational-db",
-    require_cmr_mesh = "require-cmr-mesh",
-    secrets          = "secrets",
-    service_mesh     = "service-mesh",
-    logging          = "logging",
+    dashboard_links      = "dashboard-links",
+    ingress              = "ingress",
+    istio_ingress_route  = "istio-ingress-route",
+    object_storage       = "object-storage",
+    pod_defaults         = "pod-defaults",
+    relational_db        = "relational-db",
+    require_cmr_mesh     = "require-cmr-mesh",
+    s3_credentials       = "s3-credentials",
+    secrets              = "secrets",
+    service_mesh         = "service-mesh",
+    logging              = "logging",
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -12,16 +12,16 @@ output "provides" {
 
 output "requires" {
   value = {
-    dashboard_links      = "dashboard-links",
-    ingress              = "ingress",
-    istio_ingress_route  = "istio-ingress-route",
-    object_storage       = "object-storage",
-    pod_defaults         = "pod-defaults",
-    relational_db        = "relational-db",
-    require_cmr_mesh     = "require-cmr-mesh",
-    s3_credentials       = "s3-credentials",
-    secrets              = "secrets",
-    service_mesh         = "service-mesh",
-    logging              = "logging",
+    dashboard_links     = "dashboard-links",
+    ingress             = "ingress",
+    istio_ingress_route = "istio-ingress-route",
+    object_storage      = "object-storage",
+    pod_defaults        = "pod-defaults",
+    relational_db       = "relational-db",
+    require_cmr_mesh    = "require-cmr-mesh",
+    s3_credentials      = "s3-credentials",
+    secrets             = "secrets",
+    service_mesh        = "service-mesh",
+    logging             = "logging",
   }
 }

--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -30,7 +30,7 @@ MYSQL_K8S = CharmSpec(
     charm="mysql-k8s", channel="8.0/stable", config={"profile": "testing"}, trust=True
 )
 RESOURCE_DISPATCHER = CharmSpec(charm="resource-dispatcher", channel="latest/edge", trust=True)
-S3_INTEGRATOR = CharmSpec(charm="s3-integrator", channel="2/edge", trust=False)
+S3_INTEGRATOR = CharmSpec(charm="s3-integrator", channel="2/stable", trust=False)
 KUBEFLOW_PROFILES = CharmSpec(
     charm="kubeflow-profiles",
     channel="latest/edge",


### PR DESCRIPTION
This PR adds a missing `s3-credentials` output to the Terraform module.