### PR TITLE
chore: Update data-platform-workflows to v51.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
     name: Build charm | ${{ matrix.charm }}
     needs:
       - get-charm-paths-track
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v49.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v51.0.0
     with:
       path-to-charm-directory: ${{ matrix.charm }}
       cache: true
@@ -105,15 +105,13 @@ jobs:
     needs:
       - get-charm-paths-track
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_pr.yaml@v49.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_pr.yaml@v51.0.0
     with:
       track: ${{ needs.get-charm-paths-track.outputs.track }}
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
       path-to-charm-directory: ${{ matrix.charm }}
-      # Pin < 4.4.1 (amd64 rev 8022): 4.4.1 hard-switched candid -> Ubuntu One auth, breaking release tokens.
-      charmcraft-snap-revision: 8022  # TODO: restore by removing this
     secrets:
-      charmhub-token: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN_EDGE_PR }}
     permissions:
       actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
       contents: read

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -23,10 +23,7 @@ jobs:
     steps:
       - name: Install charmcraft
         run: |
-          # Pin < 4.4.1 (amd64 rev 8022): 4.4.1 hard-switched candid -> Ubuntu One auth, breaking release tokens.
-          sudo snap install charmcraft --classic --revision 8022
-          # TODO: restore this instead:
-          # sudo snap install charmcraft --classic --channel latest/stable
+          sudo snap install charmcraft --classic --channel latest/stable
       - name: Run charmcraft promote
         run: |
           charmcraft promote --name ${{ github.event.inputs.charm-name }} \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,15 +23,13 @@ jobs:
     name: Release charm | ${{ matrix.charm }}
     needs:
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v49.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v51.0.0
     with:
       track: ${{ needs.ci-tests.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
       path-to-charm-directory: ${{ matrix.charm }}
-      # Pin < 4.4.1 (amd64 rev 8022): 4.4.1 hard-switched candid -> Ubuntu One auth, breaking release tokens.
-      charmcraft-snap-revision: 8022  # TODO: restore by removing this
     secrets:
-      charmhub-token: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN_EDGE }}
     permissions:
       actions: read
       contents: write  # Needed to create git tags


### PR DESCRIPTION
## Description

This PR updates the version of `data-platform-workflows` actions to version `v51.0.0`.

## Notes
- We're using the new environment secrets `CHARMHUB_TOKEN_EDGE` and `CHARMHUB_TOKEN_EDGE_PR` that *should* be available in the repository for the workflow to work.
- Unpin the revision in the `release.yaml` workflow, since I regenerated the `CHARMCRAFT_CREDENTIALS` secret.

Base issue: https://github.com/canonical/bundle-kubeflow/issues/1462
